### PR TITLE
fixed percentage not updating: reference branch for coverage set to dev

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -89,3 +89,5 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           with:
           file: ${{ env.COVERAGE_REPORT_XML }}
+          override_branch: ${{ github.base_ref }}
+          override_commit: ${{ github.event.pull_request.base.sha }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">QuAOS </h1><br>
 
-[![codecov](https://codecov.io/gh/QuAOS-Lab/quaos/branch/test-workflow-all/graph/badge.svg?token=AMHLXLAKCD)](https://codecov.io/gh/QuAOS-Lab/quaos)
+[![codecov](https://codecov.io/gh/QuAOS-Lab/quaos/graph/badge.svg?token=AMHLXLAKCD)](https://codecov.io/gh/QuAOS-Lab/quaos)
 
 In progress...


### PR DESCRIPTION
Updated README.md coverage-badge to be branch-independent. The coverage report badge will always refer to the last coverage report uploaded **from a PR in dev** (even if we are in the main branch page). For the moment, this can be accepted; we can change this in the future if we realize the difference between the coverage scores of the two branches is too high.  