### PR TITLE
Added main-specific branch check

### DIFF
--- a/.github/workflows/pr_source_check.yml
+++ b/.github/workflows/pr_source_check.yml
@@ -1,0 +1,25 @@
+name: PR Source Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-allowed-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch
+        run: |
+          echo "Target branch: ${{ github.base_ref }}"
+          echo "Source branch: ${{ github.head_ref }}"
+
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            if [[ "${{ github.head_ref }}" == "release" ]]; then
+              echo "Allowed branch"
+              exit 0
+            else
+              echo "❌ Pull requests to 'main' must come from the 'release' branch."
+              exit 1
+            fi
+          fi

--- a/.github/workflows/pr_source_check.yml
+++ b/.github/workflows/pr_source_check.yml
@@ -2,8 +2,7 @@ name: PR Source Check
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main, dev]
 
 jobs:
   check-allowed-branches:
@@ -15,11 +14,17 @@ jobs:
           echo "Source branch: ${{ github.head_ref }}"
 
           if [[ "${{ github.base_ref }}" == "main" ]]; then
-            if [[ "${{ github.head_ref }}" == "release" ]]; then
-              echo "Allowed branch"
-              exit 0
-            else
-              echo "❌ Pull requests to 'main' must come from the 'release' branch."
-              exit 1
-            fi
+              if [[ "${{ github.head_ref }}" != "release" ]]; then
+                  echo "❌ Pull requests to 'main' must come from the 'release' branch."
+                  exit 1
+              fi
           fi
+
+          if [[ "${{ github.base_ref }}" == "dev" ]]; then
+              if [[ "${{ github.head_ref }}" == "main" ]]; then
+                  echo "❌ Direct pull requests from 'main' to 'dev' are not allowed."
+                  exit 1
+              fi
+          fi
+
+          exit 0


### PR DESCRIPTION
From now on, every merged pull request will automatically remove the source branch from which the PR has been opened.
This is to maintain the repo as clean as possible. 
It follows that PR cannot be opened directly from dev to main (to avoid having it deleted every time). 

For this reason, synchronization of main and dev branches must take place through support branches, specifically:
- for PR from **dev** to **main**: _dev -> **release** -> main_
- for PR from **main** to **dev**: _main -> **downstream** -> dev_
