### PR TITLE
Remove dimensions from gates and refactor Circuits

### DIFF
--- a/src/sympleq/core/circuits/__init__.py
+++ b/src/sympleq/core/circuits/__init__.py
@@ -1,4 +1,4 @@
 from .circuits import Circuit
-from .gates import Gate, SUM, SWAP, CNOT, Hadamard, PHASE
+from .gates import Gate, GATES
 
-__all__ = ["Circuit", "Gate", "SUM", "SWAP", "CNOT", "Hadamard", "PHASE"]
+__all__ = ["Circuit", "Gate", "GATES"]

--- a/src/sympleq/core/circuits/circuits.py
+++ b/src/sympleq/core/circuits/circuits.py
@@ -5,7 +5,7 @@ from .utils import embed_symplectic
 import scipy.sparse as sp
 import random
 
-from .gates import Hadamard as H, SUM, PHASE, Gate, SWAP, CNOT
+from .gates import GATES, Hadamard as H, SUM, PHASE, Gate, SWAP, CNOT
 from sympleq.core.paulis import PauliSum, PauliString, Pauli, PauliObject
 
 
@@ -15,7 +15,7 @@ P = TypeVar("P", bound="PauliObject")
 
 
 class Circuit:
-    def __init__(self, gates: list[Gate] | None = None):
+    def __init__(self, gates: list[Gate] = [], qudit_indices: list[int | tuple[int]] = []):
         """
         Initialize the Circuit with gates, indexes, and targets.
 
@@ -35,9 +35,8 @@ class Circuit:
 
         TODO: Perhaps store the composite gate as an attribute - it will allow gate.act to be significantly faster
         """
-        if gates is None:
-            gates = []
         self.gates = gates
+        self.qudit_indices = qudit_indices
 
     @classmethod
     def from_random(cls, n_qudits: int, depth: int) -> 'Circuit':
@@ -51,21 +50,12 @@ class Circuit:
         Returns:
             Circuit: A new Circuit object.
         """
-        gate_list = [H, PHASE, SUM]
-        gg = []
+        gates = []
         # FIXME: add weight of 2 qubits gates
-        for _ in range(depth):
-            g_i = np.random.randint(g_max)
-            if g_i == 2:
-                aa = list(random.sample(range(n_qudits), 2))
-                while aa[0] == aa[1] or dimensions[aa[0]] != dimensions[aa[1]]:
-                    aa = list(random.sample(range(n_qudits), 2))
-                gg += [gate_list[g_i](aa[0], aa[1])]
-            else:
-                aa = list(random.sample(range(n_qudits), 1))
-                gg += [gate_list[g_i](aa[0])]
-
-        return cls(gg)
+        gates = [GATES.H, GATES.S, GATES.swap, GATES.cnot, GATES.sum]
+        gates = np.random.choice(np.asarray(
+            [GATES.H, GATES.S, GATES.swap, GATES.cnot, GATES.sum]), size=depth, replace=True).tolist()
+        return cls(gates)
 
     def add_gate(self, gates: Gate | list[Gate]):
         """
@@ -121,36 +111,36 @@ class Circuit:
         return "\n".join([g.name for g in self.gates])
 
     @overload
-    def act(self, pauli: Pauli, qudit_indices: int | list[int]) -> Pauli:
+    def act(self, pauli: Pauli) -> Pauli:
         ...
 
     @overload
-    def act(self, pauli: PauliString, qudit_indices: int | list[int]) -> PauliString:
+    def act(self, pauli: PauliString) -> PauliString:
         ...
 
     @overload
-    def act(self, pauli: PauliSum, qudit_indices: int | list[int]) -> PauliSum:
+    def act(self, pauli: PauliSum) -> PauliSum:
         ...
 
-    def act(self, pauli: Pauli | PauliString | PauliSum, qudit_indices: int | list[int]) -> Pauli | PauliString | PauliSum:
-        for gate in self.gates:
+    def act(self, pauli: Pauli | PauliString | PauliSum) -> Pauli | PauliString | PauliSum:
+        for (qudit_indices, gate) in zip(, self.quself.gates):
             pauli = gate.act(pauli, qudit_indices)
 
         return pauli
 
     @overload
-    def act_iter(self, pauli: Pauli, qudit_indices: int | list[int]) -> Generator[Pauli, None, None]:
+    def act_iter(self, pauli: Pauli) -> Generator[Pauli, None, None]:
         ...
 
     @overload
-    def act_iter(self, pauli: PauliString, qudit_indices: int | list[int]) -> Generator[PauliString, None, None]:
+    def act_iter(self, pauli: PauliString) -> Generator[PauliString, None, None]:
         ...
 
     @overload
-    def act_iter(self, pauli: PauliSum, qudit_indices: int | list[int]) -> Generator[PauliSum, None, None]:
+    def act_iter(self, pauli: PauliSum) -> Generator[PauliSum, None, None]:
         ...
 
-    def act_iter(self, pauli: Pauli | PauliString | PauliSum, qudit_indices: int | list[int]) -> Generator[Pauli | PauliString | PauliSum, None, None]:
+    def act_iter(self, pauli: Pauli | PauliString | PauliSum) -> Generator[Pauli | PauliString | PauliSum, None, None]:
         for gate in self.gates:
             pauli_sum = gate.act(pauli, qudit_indices)
             yield pauli_sum
@@ -162,7 +152,7 @@ class Circuit:
 
         for gate in self.gates:
             name = gate.name
-            if len(gate.qudit_indices) == 2:
+            if gate.n_qudits() == 2:
                 dict[name](gate.qudit_indices[0], gate.qudit_indices[1])
             else:
                 dict[name](gate.qudit_indices[0])
@@ -171,7 +161,7 @@ class Circuit:
         # return circuit
 
     def copy(self) -> 'Circuit':
-        return Circuit(self.dimensions, self.gates.copy())
+        return Circuit(self.gates, self.qudit_indices)
 
     def embed_circuit(self, circuit: 'Circuit', qudit_indices: list[int] | np.ndarray | None = None):
         """
@@ -236,7 +226,7 @@ class Circuit:
 
         total_indexes = list(set(np.sort(total_indexes)))
         total_symplectic = total_symplectic.T
-        return Gate('CompositeGate', total_indexes, total_symplectic, self.dimensions, total_phase_vector)
+        return Gate('CompositeGate', total_symplectic, total_phase_vector)
 
     def unitary(self) -> sp.csr_matrix:
         known_unitaries = (H, PHASE, SUM, SWAP, CNOT)

--- a/src/sympleq/core/circuits/circuits.py
+++ b/src/sympleq/core/circuits/circuits.py
@@ -8,7 +8,7 @@ from .utils import embed_symplectic
 import scipy.sparse as sp
 import random
 
-from .gates import GATES, Hadamard as H, SUM, PHASE, Gate, SWAP
+from .gates import GATES, Gate
 from sympleq.core.paulis import PauliSum, PauliString, Pauli, PauliObject
 
 GateTuple: TypeAlias = tuple[Gate, *tuple[int, ...]]
@@ -20,8 +20,7 @@ P = TypeVar("P", bound="PauliObject")
 
 
 class Circuit:
-    def __init__(self, n_qudits: int | None = None,
-                 gates: np.ndarray | list[Gate] = [], qudits: np.ndarray | list[list[int]] = []):
+    def __init__(self, n_qudits: int | None = None, gates: list[Gate] = [], qudits: list[tuple[int, ...]] = []):
         """
         Initialize the Circuit with gates, qudits.
 
@@ -41,11 +40,13 @@ class Circuit:
 
         TODO: Perhaps store the composite gate as an attribute - it will allow gate.act to be significantly faster
         """
+
+        self._gates = gates
+        self._qudits = qudits
+
         if n_qudits is None:
-            n_qudits = int(max([idx for q_indices in qudits for idx in q_indices]) + 1)
+            n_qudits = max([idx for q_indices in qudits for idx in q_indices]) + 1
         self._n_qudits = n_qudits
-        self._gates = np.asarray(gates, dtype=object)
-        self._qudits = np.asarray(qudits, dtype=object)
 
     @classmethod
     def empty(cls) -> Circuit:
@@ -64,15 +65,13 @@ class Circuit:
             Circuit: A new Circuit object.
         """
         # FIXME: add weight of 2 qubits gates
-        if n_qudits > 1:
-            available_gates = np.asarray(
-                [GATES.H, GATES.S, GATES.swap, GATES.cnot, GATES.sum])
+        if n_qudits == 1:
+            available_gates = np.asarray([GATES.H, GATES.S])
         else:
-            available_gates = np.asarray(
-                [GATES.H, GATES.S])
+            available_gates = np.asarray([GATES.H, GATES.S, GATES.swap, GATES.cnot, GATES.sum])
 
-        gates = np.random.choice(available_gates, size=depth, replace=True)
-        qudits = [[random.randint(0, n_qudits - 1) for _ in range(g.n_qudits())] for g in gates]
+        gates = np.random.choice(available_gates, size=depth, replace=True).tolist()
+        qudits = [tuple(random.sample(range(n_qudits), g.n_qudits())) for g in gates]
         C = cls(n_qudits, gates, qudits)
         C._sanity_check()
         return C
@@ -95,7 +94,7 @@ class Circuit:
             data = [data]
 
         gates = [d[0] for d in data]
-        qudits = [list(d[1:]) for d in data]
+        qudits = [tuple(d[1:]) for d in data]
         C = cls(gates=gates, qudits=qudits)
         C._sanity_check()
         return C
@@ -105,47 +104,42 @@ class Circuit:
 
     size = n_qudits
 
-    def gates(self) -> np.ndarray:
+    def gates(self) -> list[Gate]:
         return self._gates
 
-    def qudits(self) -> np.ndarray:
+    def qudits(self) -> list[tuple[int, ...]]:
         return self._qudits
 
     def add_gate(self, gate: Gate, *qudits: int):
         """
         Appends a gate to qudit index with specified target (if relevant).
-        If the number of qudits of the Circuit is smaller than any qudit index,
+        NOTE: If the number of qudits of the Circuit is smaller than any qudit index,
         it is increased as to match it.
         """
 
         if len(qudits) != gate.n_qudits():
             raise ValueError(f"Gate {gate} acts on {gate.n_qudits()} qudits, but {len(qudits)} qudits were passed.")
+        self._gates = self._gates + [gate]
+        self._qudits = self._qudits + [qudits]
+        self._n_qudits = max(self._n_qudits, max(qudits) + 1)
 
-        self._gates = np.concatenate(self._gates, np.asarray(gate), dtype=object)
-        self._qudits = np.concatenate(self._qudits, np.asarray(list[qudits]), dtype=object)
-        self._n_qudits = int(max([idx for q_indices in self._qudits for idx in q_indices]) + 1)
-
-    def add_gates(self, gates: list[Gate], *qudits: list[int]):
+    def add_gates(self, gates: list[Gate], qudits: list[tuple[int, ...]]):
         """
         Appends a gate to qudit index with specified target (if relevant).
-        If the number of qudits of the Circuit is smaller than any qudit index,
+        NOTE: If the number of qudits of the Circuit is smaller than any qudit index,
         it is increased as to match it.
         """
 
         for (gate_qudits, gate) in zip(qudits, gates):
-            if len(gate_qudits) != gate.n_qudits():
-                raise ValueError(f"Gate {gate} acts on {gate.n_qudits()} qudits, but {len(qudits)} qudits were passed.")
-
-        self._gates = np.concatenate(self._gates, np.asarray(gates), dtype=object)
-        self._qudits = np.concatenate(self._qudits, np.asarray(qudits), dtype=object)
-        self._n_qudits = int(max([idx for q_indices in self._qudits for idx in q_indices]) + 1)
+            self.add_gate(gate, *gate_qudits)
 
     def remove_gate(self, index: int):
         """
-        Removes a gate from the circuit at the specified index
+        Removes a gate from the circuit at the specified index.
+        NOTE: this does not update the number of qudits in the circuit.
         """
-        np.delete(self._gates, index)
-        np.delete(self._qudits, index)
+        self._gates.pop(index)
+        self._qudits.pop(index)
 
     def __add__(self, other: Circuit) -> Circuit:
         """
@@ -154,8 +148,8 @@ class Circuit:
         if not isinstance(other, Circuit):
             raise TypeError("Can only add another Circuit object.")
 
-        new_gates = np.concatenate(self.gates(), other.gates())
-        new_qudits = np.concatenate(self.qudits(), other.qudits())
+        new_gates = self.gates() + other.gates()
+        new_qudits = self.qudits() + other.qudits()
 
         return Circuit(gates=new_gates, qudits=new_qudits)
 
@@ -184,7 +178,8 @@ class Circuit:
         return len(self.gates())
 
     def __str__(self) -> str:
-        return "\n".join([f"{gate.name} {' '.join(qudits)}" for qudits, gate in zip(self.qudits(), self.gates())])
+        return f"Circuit on {self.n_qudits()} qudits\n" + \
+            ",\n".join([f"{gate.name()} {qudits}" for qudits, gate in zip(self.qudits(), self.gates())])
 
     @overload
     def act(self, pauli: Pauli) -> Pauli:
@@ -196,10 +191,6 @@ class Circuit:
 
     @overload
     def act(self, pauli: PauliSum) -> PauliSum:
-        ...
-
-    @overload
-    def act(self, pauli: Pauli | PauliString | PauliSum) -> Pauli | PauliString | PauliSum:
         ...
 
     def act(self, pauli: P) -> P:
@@ -231,7 +222,7 @@ class Circuit:
                 'Hdag': circuit.h}
 
         for (qudits, gate) in zip(self.qudits(), self.gates()):
-            name = gate.name
+            name = gate.name()
             if gate.n_qudits() == 2:
                 dict[name](qudits[0], qudits[1])
             else:
@@ -282,8 +273,8 @@ class Circuit:
         total_indexes = []
         total_symplectic = np.eye(2 * self.n_qudits(), dtype=np.uint8)
         for i, (qudits, gate) in enumerate(zip(self.qudits(), self.gates())):
-            symplectic = gate.symplectic
-            phase_vector = gate.phase_vector
+            symplectic = gate.symplectic()
+            phase_vector = gate.phase_vector()
 
             F, h = embed_symplectic(symplectic, phase_vector, qudits, self.n_qudits())
             if i == 0:
@@ -293,27 +284,24 @@ class Circuit:
 
             # NOTE: we do not take modulo 2*lcm here.
             total_symplectic = total_symplectic @ F.T
-            total_indexes.extend(qudits)
+            total_indexes += [qudits]
 
-        total_indexes = list(set(np.sort(total_indexes)))
+        # total_indexes = tuple(set(np.sort(total_indexes)))
         total_symplectic = total_symplectic.T
         return Gate('CompositeGate', total_symplectic, total_phase_vector)
 
     def unitary(self, dimensions: int | list[int] | np.ndarray | None = None) -> sp.csr_matrix:
         if dimensions is None:
-            dimensions = np.ones(self.n_qudits()) * DEFAULT_QUDIT_DIMENSION
+            dimensions = np.ones(self.n_qudits(), dtype=int) * DEFAULT_QUDIT_DIMENSION
         else:  # Catches int but also list and arrays of length 1
             dimensions = np.asarray(dimensions, dtype=int)
             if dimensions.ndim == 0:
                 dimensions = np.full(self.n_qudits(), dimensions.item(), dtype=int)
 
-        known_unitaries = (H, PHASE, SUM, SWAP)
-        if not np.all([isinstance(gate, known_unitaries) for gate in self.gates()]):
-            raise NotImplementedError("Unitary not implemented for all gates in the circuit.")
-
-        m = sp.csr_matrix(([1] * (np.prod(dimensions)), (range(np.prod(dimensions)), range(np.prod(dimensions)))))
-        for g in self.gates():
-            m = g.unitary(dimensions) @ m
+        D = np.prod(dimensions)
+        m = sp.csr_matrix(([1] * D, (range(D), range(D))))
+        for qudits, gate in zip(self.qudits(), self.gates()):
+            m = gate.unitary(qudits, dimensions) @ m
 
         return m
 

--- a/src/sympleq/core/circuits/circuits.py
+++ b/src/sympleq/core/circuits/circuits.py
@@ -1,12 +1,17 @@
-from typing import Generator, overload, TypeVar
+from __future__ import annotations
+from typing import Generator, overload, TypeVar, TypeAlias
 import numpy as np
 from qiskit import QuantumCircuit
+
+from sympleq.core.paulis.constants import DEFAULT_QUDIT_DIMENSION
 from .utils import embed_symplectic
 import scipy.sparse as sp
 import random
 
-from .gates import GATES, Hadamard as H, SUM, PHASE, Gate, SWAP, CNOT
+from .gates import GATES, Hadamard as H, SUM, PHASE, Gate, SWAP
 from sympleq.core.paulis import PauliSum, PauliString, Pauli, PauliObject
+
+GateTuple: TypeAlias = tuple[Gate, *tuple[int, ...]]
 
 
 # We define a type using TypeVar to let the type checker know that
@@ -15,15 +20,16 @@ P = TypeVar("P", bound="PauliObject")
 
 
 class Circuit:
-    def __init__(self, gates: list[Gate] = [], qudit_indices: list[int | tuple[int]] = []):
+    def __init__(self, n_qudits: int | None = None,
+                 gates: np.ndarray | list[Gate] = [], qudits: np.ndarray | list[list[int]] = []):
         """
-        Initialize the Circuit with gates, indexes, and targets.
+        Initialize the Circuit with gates, qudits.
 
         If a multi-qubit gate has a target, the targets should be at the ent of the tuple of indexes
         e.g. a CNOT with control 1, target 3 is
 
         gate = 'CNOT'
-        indexes = (1, 3)
+        qudits = (1, 3)
 
 
         Parameters:
@@ -35,11 +41,18 @@ class Circuit:
 
         TODO: Perhaps store the composite gate as an attribute - it will allow gate.act to be significantly faster
         """
-        self.gates = gates
-        self.qudit_indices = qudit_indices
+        if n_qudits is None:
+            n_qudits = int(max([idx for q_indices in qudits for idx in q_indices]) + 1)
+        self._n_qudits = n_qudits
+        self._gates = np.asarray(gates, dtype=object)
+        self._qudits = np.asarray(qudits, dtype=object)
 
     @classmethod
-    def from_random(cls, n_qudits: int, depth: int) -> 'Circuit':
+    def empty(cls) -> Circuit:
+        return Circuit(n_qudits=0, gates=[], qudits=[])
+
+    @classmethod
+    def from_random(cls, n_qudits: int, depth: int) -> Circuit:
         """
         Creates a random circuit with the given number of qudits and depth.
 
@@ -50,65 +63,128 @@ class Circuit:
         Returns:
             Circuit: A new Circuit object.
         """
-        gates = []
         # FIXME: add weight of 2 qubits gates
-        gates = [GATES.H, GATES.S, GATES.swap, GATES.cnot, GATES.sum]
-        gates = np.random.choice(np.asarray(
-            [GATES.H, GATES.S, GATES.swap, GATES.cnot, GATES.sum]), size=depth, replace=True).tolist()
-        return cls(gates)
+        if n_qudits > 1:
+            available_gates = np.asarray(
+                [GATES.H, GATES.S, GATES.swap, GATES.cnot, GATES.sum])
+        else:
+            available_gates = np.asarray(
+                [GATES.H, GATES.S])
 
-    def add_gate(self, gates: Gate | list[Gate]):
+        gates = np.random.choice(available_gates, size=depth, replace=True)
+        qudits = [[random.randint(0, n_qudits - 1) for _ in range(g.n_qudits())] for g in gates]
+        C = cls(n_qudits, gates, qudits)
+        C._sanity_check()
+        return C
+
+    @classmethod
+    def from_data(cls, data: GateTuple | list[GateTuple]) -> Circuit:
         """
-        Appends a gate to qudit index with specified target (if relevant)
+        Creates a circuit from the given gates and qudits data.
 
-        If gate is a list indexes should be a list of integers or tuples
+        Parameters:
+            data: list[tuple[Gate, *tuple[int, ...]]]
+                The circuit gates and qudits, given as a list of tuples.
+                Each tuple contains the Gate at first position and one or more qudit index as integer.
+
+        Returns:
+            Circuit: A new Circuit object.
         """
-        if isinstance(gates, Gate):
-            gates = [gates]
 
-        for g in gates:
-            self.gates.append(g)
+        if isinstance(data, tuple):
+            data = [data]
+
+        gates = [d[0] for d in data]
+        qudits = [list(d[1:]) for d in data]
+        C = cls(gates=gates, qudits=qudits)
+        C._sanity_check()
+        return C
+
+    def n_qudits(self) -> int:
+        return self._n_qudits
+
+    size = n_qudits
+
+    def gates(self) -> np.ndarray:
+        return self._gates
+
+    def qudits(self) -> np.ndarray:
+        return self._qudits
+
+    def add_gate(self, gate: Gate, *qudits: int):
+        """
+        Appends a gate to qudit index with specified target (if relevant).
+        If the number of qudits of the Circuit is smaller than any qudit index,
+        it is increased as to match it.
+        """
+
+        if len(qudits) != gate.n_qudits():
+            raise ValueError(f"Gate {gate} acts on {gate.n_qudits()} qudits, but {len(qudits)} qudits were passed.")
+
+        self._gates = np.concatenate(self._gates, np.asarray(gate), dtype=object)
+        self._qudits = np.concatenate(self._qudits, np.asarray(list[qudits]), dtype=object)
+        self._n_qudits = int(max([idx for q_indices in self._qudits for idx in q_indices]) + 1)
+
+    def add_gates(self, gates: list[Gate], *qudits: list[int]):
+        """
+        Appends a gate to qudit index with specified target (if relevant).
+        If the number of qudits of the Circuit is smaller than any qudit index,
+        it is increased as to match it.
+        """
+
+        for (gate_qudits, gate) in zip(qudits, gates):
+            if len(gate_qudits) != gate.n_qudits():
+                raise ValueError(f"Gate {gate} acts on {gate.n_qudits()} qudits, but {len(qudits)} qudits were passed.")
+
+        self._gates = np.concatenate(self._gates, np.asarray(gates), dtype=object)
+        self._qudits = np.concatenate(self._qudits, np.asarray(qudits), dtype=object)
+        self._n_qudits = int(max([idx for q_indices in self._qudits for idx in q_indices]) + 1)
 
     def remove_gate(self, index: int):
         """
         Removes a gate from the circuit at the specified index
         """
-        self.gates.pop(index)
+        np.delete(self._gates, index)
+        np.delete(self._qudits, index)
 
-    def __add__(self, other: "Circuit | Gate") -> "Circuit":
+    def __add__(self, other: Circuit) -> Circuit:
         """
         Adds two circuits together by concatenating their gates and indexes.
         """
-        if not isinstance(other, Circuit) and not isinstance(other, Gate):
-            raise TypeError("Can only add another Circuit or Gate object.")
+        if not isinstance(other, Circuit):
+            raise TypeError("Can only add another Circuit object.")
 
-        if isinstance(other, Gate):
-            new_gates = self.gates + [other]
-        else:
-            new_gates = self.gates + other.gates
-        return Circuit(new_gates)
+        new_gates = np.concatenate(self.gates(), other.gates())
+        new_qudits = np.concatenate(self.qudits(), other.qudits())
 
-    def __eq__(self, other: 'Circuit') -> bool:
+        return Circuit(gates=new_gates, qudits=new_qudits)
+
+    def __eq__(self, other: Circuit) -> bool:
         if not isinstance(other, Circuit):
             return False
-        if len(self.gates) != len(other.gates):
+        if len(self.gates()) != len(other.gates()):
             return False
-        for i in range(len(self.gates)):
-            if self.gates[i] != other.gates[i]:
+        for i in range(len(self.gates())):
+            if self.gates()[i] != other.gates()[i]:
+                return False
+        if len(self.qudits()) != len(other.qudits()):
+            return False
+        for i in range(len(self.qudits())):
+            if self.qudits()[i] != other.qudits()[i]:
                 return False
         return True
 
-    def __getitem__(self, index: int) -> Gate:
-        return self.gates[index]
+    def __getitem__(self, index: int) -> tuple[Gate, tuple[int, ...]]:
+        return self.gates()[index], self.qudits()[index]
 
     def __setitem__(self, index: int, value: Gate):
-        self.gates[index] = value
+        self.gates()[index] = value
 
     def __len__(self) -> int:
-        return len(self.gates)
+        return len(self.gates())
 
     def __str__(self) -> str:
-        return "\n".join([g.name for g in self.gates])
+        return "\n".join([f"{gate.name} {' '.join(qudits)}" for qudits, gate in zip(self.qudits(), self.gates())])
 
     @overload
     def act(self, pauli: Pauli) -> Pauli:
@@ -122,9 +198,13 @@ class Circuit:
     def act(self, pauli: PauliSum) -> PauliSum:
         ...
 
+    @overload
     def act(self, pauli: Pauli | PauliString | PauliSum) -> Pauli | PauliString | PauliSum:
-        for (qudit_indices, gate) in zip(, self.quself.gates):
-            pauli = gate.act(pauli, qudit_indices)
+        ...
+
+    def act(self, pauli: P) -> P:
+        for (qudits, gate) in zip(self.qudits(), self.gates()):
+            pauli = gate.act(pauli, qudits)
 
         return pauli
 
@@ -140,46 +220,41 @@ class Circuit:
     def act_iter(self, pauli: PauliSum) -> Generator[PauliSum, None, None]:
         ...
 
-    def act_iter(self, pauli: Pauli | PauliString | PauliSum) -> Generator[Pauli | PauliString | PauliSum, None, None]:
-        for gate in self.gates:
-            pauli_sum = gate.act(pauli, qudit_indices)
+    def act_iter(self, pauli: P) -> Generator[P, None, None]:
+        for (qudits, gate) in zip(self.qudits(), self.gates()):
+            pauli_sum = gate.act(pauli, qudits)
             yield pauli_sum
 
-    def show(self):
-        circuit = QuantumCircuit(len(self.dimensions))
+    def show(self, n_qudits: int):
+        circuit = QuantumCircuit(n_qudits)
         dict = {'X': circuit.x, 'H': circuit.h, 'S': circuit.s, 'SUM': circuit.cx, 'CNOT': circuit.cx,
                 'Hdag': circuit.h}
 
-        for gate in self.gates:
+        for (qudits, gate) in zip(self.qudits(), self.gates()):
             name = gate.name
             if gate.n_qudits() == 2:
-                dict[name](gate.qudit_indices[0], gate.qudit_indices[1])
+                dict[name](qudits[0], qudits[1])
             else:
-                dict[name](gate.qudit_indices[0])
+                dict[name](qudits[0])
 
         print(circuit)
         # return circuit
 
-    def copy(self) -> 'Circuit':
-        return Circuit(self.gates, self.qudit_indices)
+    def copy(self) -> Circuit:
+        return Circuit(self.n_qudits(), self.gates().copy(), self.qudits().copy())
 
-    def embed_circuit(self, circuit: 'Circuit', qudit_indices: list[int] | np.ndarray | None = None):
+    def embed_circuit(self, circuit: Circuit, qudits: list[int] | np.ndarray | None = None):
         """
         Embed a circuit into current circuit at the specified qudit indices.
         """
+        # FIXME: ask what this is supposed to do
 
-        if qudit_indices is not None:
-            if len(qudit_indices) != circuit.n_qudits():
-                raise ValueError("Number of qudit indices does not match number of qudits in circuit to embed")
+        # for (qudits, gate) in zip(self.qudits(), self.gates()):
+        #     new_qudits = [qudits[j] for j in gate.qudits]
+        #     new_gate.qudits = np.ndarray(new_indexes)
+        #     self.add_gate(new_gate)
 
-        for gate in circuit.gates:
-            new_gate = gate.copy()
-            if qudit_indices is not None:
-                new_indexes = [qudit_indices[j] for j in gate.qudit_indices]
-                new_gate.qudit_indices = np.ndarray(new_indexes)
-            self.add_gate(new_gate)
-
-    def _composite_phase_vector(self, F_1: np.ndarray, F_2: np.ndarray, h_2: np.ndarray, lcm: int) -> np.ndarray:
+    def _composite_phase_vector(self, F_1: np.ndarray, F_2: np.ndarray, h_2: np.ndarray) -> np.ndarray:
         """
         Returns the vector to add to h_1 to obtain h'' in PHYSICAL REVIEW A 71, 042315 (2005) - Eq. (8)
 
@@ -196,7 +271,8 @@ class Circuit:
         p2 = np.diag(np.dot(F_1, np.dot((2 * np.triu(U_conjugated) - np.diag(np.diag(U_conjugated))), F_1.T)))
         p3 = np.dot(F_1, np.diag(U_conjugated))
 
-        h_c = (p1 + p2 - p3) % (2 * lcm)
+        # NOTE: we do not take modulo 2*lcm here.
+        h_c = (p1 + p2 - p3)
 
         return h_c
 
@@ -205,38 +281,65 @@ class Circuit:
 
         total_indexes = []
         total_symplectic = np.eye(2 * self.n_qudits(), dtype=np.uint8)
-        lcm = np.lcm.reduce(self.dimensions)
-        for i, gate in enumerate(self.gates):
+        for i, (qudits, gate) in enumerate(zip(self.qudits(), self.gates())):
             symplectic = gate.symplectic
-            indexes = gate.qudit_indices
             phase_vector = gate.phase_vector
 
-            F, h = embed_symplectic(symplectic, phase_vector, indexes, self.n_qudits())  #
+            F, h = embed_symplectic(symplectic, phase_vector, qudits, self.n_qudits())
             if i == 0:
                 total_phase_vector = h
             else:
-                total_phase_vector = np.mod(total_phase_vector + self._composite_phase_vector(total_symplectic, F, h,
-                                                                                              lcm),
-                                            2 * lcm)
-            print(phase_vector, total_phase_vector)
+                total_phase_vector = total_phase_vector + self._composite_phase_vector(total_symplectic, F, h)
 
-            total_symplectic = np.mod(total_symplectic @ F.T, lcm)
-
-            total_indexes.extend(indexes)
+            # NOTE: we do not take modulo 2*lcm here.
+            total_symplectic = total_symplectic @ F.T
+            total_indexes.extend(qudits)
 
         total_indexes = list(set(np.sort(total_indexes)))
         total_symplectic = total_symplectic.T
         return Gate('CompositeGate', total_symplectic, total_phase_vector)
 
-    def unitary(self) -> sp.csr_matrix:
-        known_unitaries = (H, PHASE, SUM, SWAP, CNOT)
-        if not np.all([isinstance(gate, known_unitaries) for gate in self.gates]):
-            print(self.gates)
+    def unitary(self, dimensions: int | list[int] | np.ndarray | None = None) -> sp.csr_matrix:
+        if dimensions is None:
+            dimensions = np.ones(self.n_qudits()) * DEFAULT_QUDIT_DIMENSION
+        else:  # Catches int but also list and arrays of length 1
+            dimensions = np.asarray(dimensions, dtype=int)
+            if dimensions.ndim == 0:
+                dimensions = np.full(self.n_qudits(), dimensions.item(), dtype=int)
+
+        known_unitaries = (H, PHASE, SUM, SWAP)
+        if not np.all([isinstance(gate, known_unitaries) for gate in self.gates()]):
             raise NotImplementedError("Unitary not implemented for all gates in the circuit.")
 
-        q = self.dimensions
-        m = sp.csr_matrix(([1] * (np.prod(q)), (range(np.prod(q)), range(np.prod(q)))))
-        for g in self.gates:
-            m = g.unitary(dims=self.dimensions) @ m
+        m = sp.csr_matrix(([1] * (np.prod(dimensions)), (range(np.prod(dimensions)), range(np.prod(dimensions)))))
+        for g in self.gates():
+            m = g.unitary(dimensions) @ m
 
         return m
+
+    def _sanity_check(self):
+        """
+        Validates the consistency of the Circuit internal representation.
+
+        Raises
+        ------
+        ValueError
+            If any qudit index is large equal than the number of qudits.
+        """
+
+        if len(self.gates()) != len(self.qudits()):
+            raise ValueError(
+                f"There should be the same number of gates ({len(self.gates())}) and qudits ({len(self.qudits())}).")
+
+        q = self.qudits()
+
+        # Check that each element in qudit is a non-empty list
+        lengths = np.fromiter((len(lst) for lst in q), dtype=int)
+        empty_mask = lengths == 0
+        if np.any(empty_mask):
+            empty_indices = np.where(empty_mask)[0]
+            raise ValueError(f"Gates and indices {empty_indices} must be applied to at least one qudit.")
+
+        all_qudits = np.fromiter((x for lst in q for x in lst), dtype=int, count=sum(lengths))
+        if not np.all((all_qudits >= 0) & (all_qudits < self.n_qudits())):
+            raise ValueError(f"Qudits should be between 0 and {self.n_qudits()} (number of qudits in the circuit).")

--- a/src/sympleq/core/circuits/circuits.py
+++ b/src/sympleq/core/circuits/circuits.py
@@ -15,7 +15,7 @@ P = TypeVar("P", bound="PauliObject")
 
 
 class Circuit:
-    def __init__(self, dimensions: list[int] | np.ndarray, gates: list[Gate] | None = None):
+    def __init__(self, gates: list[Gate] | None = None):
         """
         Initialize the Circuit with gates, indexes, and targets.
 
@@ -37,12 +37,10 @@ class Circuit:
         """
         if gates is None:
             gates = []
-        self.dimensions = dimensions
         self.gates = gates
-        self.indexes = [gate.qudit_indices for gate in gates]  # indexes accessible at the Circuit level
 
     @classmethod
-    def from_random(cls, n_qudits: int, depth: int, dimensions: list[int] | np.ndarray) -> 'Circuit':
+    def from_random(cls, n_qudits: int, depth: int) -> 'Circuit':
         """
         Creates a random circuit with the given number of qudits and depth.
 
@@ -53,53 +51,39 @@ class Circuit:
         Returns:
             Circuit: A new Circuit object.
         """
-        # check if all dimensions are the different
-        if len(set(dimensions)) != len(dimensions):
-            g_max = 3  # only single qudit gates if not all dimensions are different (never selects CX)
-        else:
-            g_max = 2  # all gates possible
-
         gate_list = [H, PHASE, SUM]
         gg = []
-        for i in range(depth):
+        # FIXME: add weight of 2 qubits gates
+        for _ in range(depth):
             g_i = np.random.randint(g_max)
             if g_i == 2:
                 aa = list(random.sample(range(n_qudits), 2))
                 while aa[0] == aa[1] or dimensions[aa[0]] != dimensions[aa[1]]:
                     aa = list(random.sample(range(n_qudits), 2))
-                gg += [gate_list[g_i](aa[0], aa[1], dimensions[aa[0]])]
+                gg += [gate_list[g_i](aa[0], aa[1])]
             else:
                 aa = list(random.sample(range(n_qudits), 1))
-                gg += [gate_list[g_i](aa[0], dimensions[aa[0]])]
+                gg += [gate_list[g_i](aa[0])]
 
-        return cls(dimensions, gg)
+        return cls(gg)
 
-    def add_gate(self, gate: Gate | list[Gate]):
+    def add_gate(self, gates: Gate | list[Gate]):
         """
         Appends a gate to qudit index with specified target (if relevant)
 
         If gate is a list indexes should be a list of integers or tuples
         """
-        if isinstance(gate, list) or isinstance(gate, np.ndarray):
-            for i, g in enumerate(gate):
-                self.gates.append(g)
-                self.indexes.append(g.qudit_indices)
-        else:
-            self.gates.append(gate)
-            self.indexes.append(gate.qudit_indices)
+        if isinstance(gates, Gate):
+            gates = [gates]
+
+        for g in gates:
+            self.gates.append(g)
 
     def remove_gate(self, index: int):
         """
         Removes a gate from the circuit at the specified index
         """
         self.gates.pop(index)
-        self.indexes.pop(index)
-
-    def n_qudits(self) -> int:
-        """
-        Returns the number of qudits in the circuit.
-        """
-        return len(self.dimensions)
 
     def __add__(self, other: "Circuit | Gate") -> "Circuit":
         """
@@ -107,11 +91,12 @@ class Circuit:
         """
         if not isinstance(other, Circuit) and not isinstance(other, Gate):
             raise TypeError("Can only add another Circuit or Gate object.")
+
         if isinstance(other, Gate):
             new_gates = self.gates + [other]
         else:
             new_gates = self.gates + other.gates
-        return Circuit(self.dimensions, new_gates)
+        return Circuit(new_gates)
 
     def __eq__(self, other: 'Circuit') -> bool:
         if not isinstance(other, Circuit):
@@ -128,55 +113,49 @@ class Circuit:
 
     def __setitem__(self, index: int, value: Gate):
         self.gates[index] = value
-        self.indexes[index] = value.qudit_indices
 
     def __len__(self) -> int:
         return len(self.gates)
 
     def __str__(self) -> str:
-        str_out = ''
+        return "\n".join([g.name for g in self.gates])
+
+    @overload
+    def act(self, pauli: Pauli, qudit_indices: int | list[int]) -> Pauli:
+        ...
+
+    @overload
+    def act(self, pauli: PauliString, qudit_indices: int | list[int]) -> PauliString:
+        ...
+
+    @overload
+    def act(self, pauli: PauliSum, qudit_indices: int | list[int]) -> PauliSum:
+        ...
+
+    def act(self, pauli: Pauli | PauliString | PauliSum, qudit_indices: int | list[int]) -> Pauli | PauliString | PauliSum:
         for gate in self.gates:
-            str_out += gate.name + ' ' + str(gate.qudit_indices) + '\n'
-        return str_out
-
-    @overload
-    def act(self, pauli: Pauli) -> Pauli:
-        ...
-
-    @overload
-    def act(self, pauli: PauliString) -> PauliString:
-        ...
-
-    @overload
-    def act(self, pauli: PauliSum) -> PauliSum:
-        ...
-
-    def act(self, pauli: Pauli | PauliString | PauliSum) -> Pauli | PauliString | PauliSum:
-        for gate in self.gates:
-            pauli = gate.act(pauli)
+            pauli = gate.act(pauli, qudit_indices)
 
         return pauli
 
     @overload
-    def act_iter(self, pauli: Pauli) -> Generator[Pauli, None, None]:
+    def act_iter(self, pauli: Pauli, qudit_indices: int | list[int]) -> Generator[Pauli, None, None]:
         ...
 
     @overload
-    def act_iter(self, pauli: PauliString) -> Generator[PauliString, None, None]:
+    def act_iter(self, pauli: PauliString, qudit_indices: int | list[int]) -> Generator[PauliString, None, None]:
         ...
 
     @overload
-    def act_iter(self, pauli: PauliSum) -> Generator[PauliSum, None, None]:
+    def act_iter(self, pauli: PauliSum, qudit_indices: int | list[int]) -> Generator[PauliSum, None, None]:
         ...
 
-    def act_iter(self, pauli: Pauli | PauliString | PauliSum) -> Generator[Pauli | PauliString | PauliSum, None, None]:
+    def act_iter(self, pauli: Pauli | PauliString | PauliSum, qudit_indices: int | list[int]) -> Generator[Pauli | PauliString | PauliSum, None, None]:
         for gate in self.gates:
-            pauli_sum = gate.act(pauli)
+            pauli_sum = gate.act(pauli, qudit_indices)
             yield pauli_sum
 
     def show(self):
-        if np.all(np.array(self.dimensions) != 2):
-            print("Circuit dimensions are all 2, using Qiskit QuantumCircuit, some gates may not be supported")
         circuit = QuantumCircuit(len(self.dimensions))
         dict = {'X': circuit.x, 'H': circuit.h, 'S': circuit.s, 'SUM': circuit.cx, 'CNOT': circuit.cx,
                 'Hdag': circuit.h}

--- a/src/sympleq/core/circuits/circuits.py
+++ b/src/sympleq/core/circuits/circuits.py
@@ -4,7 +4,7 @@ import numpy as np
 from qiskit import QuantumCircuit
 
 from sympleq.core.paulis.constants import DEFAULT_QUDIT_DIMENSION
-from .utils import embed_symplectic
+from .utils import embed_symplectic, embed_phase_vector
 import scipy.sparse as sp
 import random
 
@@ -213,8 +213,8 @@ class Circuit:
 
     def act_iter(self, pauli: P) -> Generator[P, None, None]:
         for (qudits, gate) in zip(self.qudits(), self.gates()):
-            pauli_sum = gate.act(pauli, qudits)
-            yield pauli_sum
+            pauli = gate.act(pauli, qudits)
+            yield pauli
 
     def show(self, n_qudits: int):
         circuit = QuantumCircuit(n_qudits)
@@ -267,28 +267,39 @@ class Circuit:
 
         return h_c
 
-    def composite_gate(self) -> Gate:
+    def composite_gate(self, dimensions: np.ndarray) -> Gate:
         """Composes the list of symplectics acting on all qudits to a single symplectic"""
 
-        total_indexes = []
         total_symplectic = np.eye(2 * self.n_qudits(), dtype=np.uint8)
+        affected_qudits = sorted(set(q for qudits in self.qudits() for q in qudits))
+        mask = np.array(affected_qudits + [q + self.n_qudits() for q in affected_qudits], dtype=int)
+
+        all_phase_dimensions = set([k for gate in self.gates() for k in gate._phase_vectors.keys()])
+        exceptional_phase_vectors = {}
         for i, (qudits, gate) in enumerate(zip(self.qudits(), self.gates())):
             symplectic = gate.symplectic()
-            phase_vector = gate.phase_vector()
+            F = embed_symplectic(symplectic, qudits, self.n_qudits())
 
-            F, h = embed_symplectic(symplectic, phase_vector, qudits, self.n_qudits())
-            if i == 0:
-                total_phase_vector = h
-            else:
-                total_phase_vector = total_phase_vector + self._composite_phase_vector(total_symplectic, F, h)
+            for d in all_phase_dimensions:
+                phase_vector_local = gate.phase_vector(d)
+                h_d = embed_phase_vector(phase_vector_local, qudits, self.n_qudits())
+                if i == 0:
+                    total_phase_vector_d = h_d
+                else:
+                    total_phase_vector_d = total_phase_vector_d + self._composite_phase_vector(total_symplectic, F, h_d)
+                exceptional_phase_vectors[d] = total_phase_vector_d[mask]
 
             # NOTE: we do not take modulo 2*lcm here.
             total_symplectic = total_symplectic @ F.T
-            total_indexes += [qudits]
 
-        # total_indexes = tuple(set(np.sort(total_indexes)))
         total_symplectic = total_symplectic.T
-        return Gate('CompositeGate', total_symplectic, total_phase_vector)
+        total_symplectic = total_symplectic[np.ix_(mask, mask)]
+        gate = Gate('CompositeGate', total_symplectic, exceptional_phase_vectors=exceptional_phase_vectors)
+
+        return gate
+
+    def affected_qudits(self) -> tuple[int, ...]:
+        return tuple(sorted(set([q for qudits in self.qudits() for q in qudits])))
 
     def unitary(self, dimensions: int | list[int] | np.ndarray | None = None) -> sp.csr_matrix:
         if dimensions is None:

--- a/src/sympleq/core/circuits/gates.py
+++ b/src/sympleq/core/circuits/gates.py
@@ -4,7 +4,7 @@ import scipy.sparse as sp
 from typing import TypeVar, overload
 
 from sympleq.core.paulis import Pauli, PauliString, PauliSum, PauliObject
-from sympleq.core.circuits.target import find_map_to_target_pauli_sum, get_phase_vector
+from sympleq.core.circuits.target import find_map_to_target_pauli_sum
 from sympleq.core.circuits.utils import transvection_matrix, symplectic_form, tensor, I_mat, H_mat, S_mat, CX_func
 
 # We define a type using TypeVar to let the type checker know that
@@ -18,14 +18,12 @@ P = TypeVar("P", bound="PauliObject")
 
 
 class Gate(ABC):
-    def __init__(self, name: str, symplectic: np.ndarray, phase_vector: np.ndarray | None = None):
+    def __init__(self, name: str, symplectic: np.ndarray, phase_vector: np.ndarray):
         self.name = name
         n_qudits = symplectic.shape[0] // 2
         self._n_qudits = n_qudits
         self.symplectic = symplectic
 
-        if phase_vector is None:
-            phase_vector = get_phase_vector(symplectic)
         self.phase_vector = phase_vector
 
         # U = [[0_n, 0_n],
@@ -65,48 +63,45 @@ class Gate(ABC):
 
         for i in range(n_transvection):
             np.random.seed(seed_vec[i])
-            # NOTE: we take the modulo 193 to avoid generating a symplectic with too large entries.
-            #       Here 193 is some 'big' prime number.
-            Tv = transvection_matrix(np.random.randint(0, size=2 * n_qudits)) % 193
+            # FIXME: Check if we should take some intermediary modulo operation to keep matrix small.
+            Tv = transvection_matrix(np.random.randint(0, size=2 * n_qudits))
             symplectic = symplectic @ Tv
 
-        return cls(f"R{n_transvection}", symplectic)
+        return cls(f"R{n_transvection}", symplectic, np.zeros(len(symplectic)))
 
     def __repr__(self):
         return f"Gate(name={self.name}, n_qudits={self._n_qudits}, phase_vector={self.phase_vector})"
 
-    @overload
-    def act(self, pauli: Pauli, qudit_indices: int | list[int]) -> Pauli:
-        ...
+    # @overload
+    # def act(self, pauli: Pauli, qudits: int | list[int] | np.ndarray | tuple[int, ...]) -> Pauli:
+    #     ...
 
-    @overload
-    def act(self, pauli: PauliString, qudit_indices: int | list[int]) -> PauliString:
-        ...
+    # @overload
+    # def act(self, pauli: PauliString, qudits: int | list[int] | np.ndarray | tuple[int, ...]) -> PauliString:
+    #     ...
 
-    @overload
-    def act(self, pauli: PauliSum, qudit_indices: int | list[int]) -> PauliSum:
-        ...
+    # @overload
+    # def act(self, pauli: PauliSum, qudits: int | list[int] | np.ndarray | tuple[int, ...]) -> PauliSum:
+    #     ...
 
-    def act(self, pauli: P, qudit_indices: int | list[int] | np.ndarray) -> P:
+    def act(self, pauli: P, *qudits: int) -> P:
         """
         Returns the updated tableau and phases acquired by the PauliSum when acted upon by this gate.
 
         See Eq.[7] in PHYSICAL REVIEW A 71, 042315 (2005)
 
         """
-        if isinstance(qudit_indices, int):
-            qudit_indices = [qudit_indices]
-        qudit_indices = np.asarray(qudit_indices, dtype=int)
 
-        pauli_dimensions = pauli.dimensions()[qudit_indices]
-
+        affected_qudits = np.asarray(qudits, dtype=int)
         T = pauli.tableau()
 
         # Precompute tableau mask. This will be applied to the PauliSum tableau to get
         # the subset of affected columns.
-        tableau_mask = np.concatenate([qudit_indices, qudit_indices + pauli.n_qudits()])
+        tableau_mask = np.concatenate([affected_qudits, affected_qudits + pauli.n_qudits()])
 
         T_affected = T[:, tableau_mask]
+
+        pauli_dimensions = pauli.dimensions()[affected_qudits]
         relevant_dimensions = np.tile(pauli_dimensions, 2)
         updated_tableau = np.mod(T_affected @ self.symplectic.T, relevant_dimensions)
         new_tableau = T.copy()
@@ -117,7 +112,7 @@ class Gate(ABC):
         quadratic_terms = np.sum(T_affected * (T_affected @ self.p_part), axis=1)
 
         # FIXME: this is a but of a hack
-        dimensional_factor = pauli.lcm() // np.lcm.reduce(pauli.dimensions()[qudit_indices])
+        dimensional_factor = pauli.lcm() // np.lcm.reduce(pauli_dimensions)
         acquired_phases = (linear_terms + quadratic_terms) * dimensional_factor
 
         new_phases = (pauli.phases() + acquired_phases) % (2 * pauli.lcm())
@@ -139,9 +134,12 @@ class Gate(ABC):
         T = transvection_matrix(transvection_vector, multiplier=transvection_weight)
         if self.name[0] != "T":
             self.name = "T-" + self.name
-        return Gate(self.name, self.symplectic @ T)
 
-    def inv(self) -> 'Gate':
+        # FIXME: generate correct phase_vector
+        phase_vector = np.zeros(len(self.symplectic))
+        return Gate(self.name, self.symplectic @ T, phase_vector)
+
+    def inverse(self) -> 'Gate':
         # TODO: Test for mixed dimensions - not clear that the symplectic form here is correct.
         print("Warning: inverse phase vector not working - PHASES MAY BE INCORRECT.")
 
@@ -161,28 +159,7 @@ class Gate(ABC):
         phase_vector = (p1 + p2 + p3)
         return Gate(self.name + "-inv", C_inv.T, phase_vector)
 
-    # def inverse(self) -> 'Gate':
-    #     """
-    #     Returns the inverse of this gate.
-
-    #     The inverse of a gate G is another gate G' such that the composition G'G is the identity.
-
-    #     The inverse of a gate is computed using the formulae presented in PHYSICAL REVIEW A 71, 042315 (2005)
-
-    #     :return: A new Gate object, the inverse of this gate.
-    #     """
-    #     n = self._n_qudits
-    #     Id_n = np.eye(n)
-    #     Zero_n = np.zeros((n, n))
-    #     U = np.block([[Zero_n, Zero_n], [Id_n, Zero_n]])
-    #     Omega = (U - U.T)
-
-    #     C = self.symplectic.T
-    #     C_inv = Omega.T @ C.T @ Omega
-
-    #     return Gate(self.name + '_inv', C_inv.T)
-
-    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         raise NotImplementedError("Unitary not implemented for generic Gate. Use specific gate subclasses.")
 
 
@@ -195,11 +172,11 @@ class SUM(Gate):
             [0, 0, -1, 1]   # image of Z1:  Z1 -> Z0^-1 Z1
         ], dtype=int).T
 
-        super().__init__("SUM", symplectic)
+        super().__init__("SUM", symplectic, np.zeros(len(symplectic)))
 
-    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         D = np.prod(dimensions)
-        aa = qudit_indices
+        aa = qudits
         a0 = aa[0]
         a1 = aa[1]
         aa2 = np.array([1 for i in range(D)])
@@ -217,12 +194,12 @@ class SWAP(Gate):
             [0, 0, 1, 0]   # image of Z1:  Z1 -> Z0
         ], dtype=int).T
 
-        super().__init__("SWAP", symplectic)
+        super().__init__("SWAP", symplectic, np.zeros(len(symplectic)))
 
-    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         # SWAP on two qudits of equal dimension: |i, j> -> |j, i>.
         # Basis ordering |i>⊗|j> with linear index idx(i, j) = i * d + j.
-        aa = qudit_indices
+        aa = qudits
         q = len(dimensions)
         D = np.prod(dimensions)
         a0 = q - 1 - aa[0]
@@ -266,11 +243,17 @@ class Hadamard(Gate):
             ], dtype=int)
 
         name = "H" if not inverse else "H_inv"
-        super().__init__(name, symplectic)
 
-    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+        # FIXME: get correct phase_vector
+        super().__init__(name, symplectic, np.zeros(len(symplectic)))
+
+    def unitary(self, qudits: int | list[int], dimensions: int | list[int] | np.ndarray) -> sp.csr_matrix:
+        if isinstance(qudits, int):
+            qudits = [qudits]
+        if isinstance(dimensions, int):
+            dimensions = [dimensions]
         return tensor(
-            [H_mat(dimensions[i]) if i in qudit_indices else I_mat(dimensions[i]) for i in range(len(dimensions))]
+            [H_mat(dimensions[i]) if i in qudits else I_mat(dimensions[i]) for i in range(len(dimensions))]
         )
 
 
@@ -281,7 +264,7 @@ class PHASE(Gate):
             [0, 1]   # image of Z:  Z -> Z
         ], dtype=int).T
 
-        super().__init__("S", symplectic)
+        super().__init__("S", symplectic, np.zeros(len(symplectic)))
 
     @classmethod
     def phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
@@ -290,8 +273,8 @@ class PHASE(Gate):
 
         return np.array([0, 0], dtype=int)
 
-    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
-        unitary = tensor([S_mat(dimensions[i]) if i in qudit_indices else I_mat(dimensions[i])
+    def unitary(self, qudits: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+        unitary = tensor([S_mat(dimensions[i]) if i in qudits else I_mat(dimensions[i])
                          for i in range(len(dimensions))])
         return unitary
 

--- a/src/sympleq/core/circuits/gates.py
+++ b/src/sympleq/core/circuits/gates.py
@@ -3,41 +3,48 @@ import numpy as np
 import scipy.sparse as sp
 from typing import TypeVar, overload
 
-from sympleq.core.circuits.find_symplectic import map_pauli_sum_to_target_tableau
 from sympleq.core.paulis import Pauli, PauliString, PauliSum, PauliObject
-from sympleq.core.circuits.target import get_phase_vector
+from sympleq.core.circuits.target import find_map_to_target_pauli_sum, get_phase_vector
 from sympleq.core.circuits.utils import transvection_matrix, symplectic_form, tensor, I_mat, H_mat, S_mat, CX_func
 
 # We define a type using TypeVar to let the type checker know that
 # the input and output of the `act` function share the same type.
 P = TypeVar("P", bound="PauliObject")
 
+# FIXME: add a general intro explaining our approach.
+#   - local manipulation on qudits
+#   - delay modulo operations
+#   - avoid embedding dimensions into gates
+
 
 class Gate(ABC):
-    def __init__(self, name: str, symplectic: np.ndarray):
+    def __init__(self, name: str, symplectic: np.ndarray, phase_vector: np.ndarray | None = None):
         self.name = name
-        n_qudits = len(symplectic) // 2
+        n_qudits = symplectic.shape[0] // 2
         self._n_qudits = n_qudits
         self.symplectic = symplectic
 
+        if phase_vector is None:
+            phase_vector = get_phase_vector(symplectic)
+        self.phase_vector = phase_vector
+
         # U = [[0_n, 0_n],
         #      [I_n, 0_n]]
-        U = np.zeros((2 * self.n_qudits, 2 * self.n_qudits), dtype=int)
-        U[self.n_qudits:, :self.n_qudits] = np.eye(self.n_qudits, dtype=int)
+        U = np.zeros((2 * self._n_qudits, 2 * self._n_qudits), dtype=int)
+        U[self._n_qudits:, :self._n_qudits] = np.eye(self._n_qudits, dtype=int)
         self.U_symplectic_conjugated = self.symplectic.T @ U @ self.symplectic
 
         self.V_diag = np.diag(self.U_symplectic_conjugated)
+
+        # This is the part associated with the linear form.
+        self.modified_phase_vector = phase_vector - self.V_diag  # h - V_diag
+
         # This is the part associated with the quadratic form.
         # We remove diagonal part to match definition in Eq.[7] in PHYSICAL REVIEW A 71, 042315 (2005).
         self.p_part = 2 * np.triu(self.U_symplectic_conjugated) - np.diag(self.V_diag)
 
-    @classmethod
-    def get_phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    @abstractmethod
     def n_qudits(self) -> int:
-        pass
+        return self._n_qudits
 
     @classmethod
     def solve_from_target(cls, name: str, input_pauli_sum: PauliSum, target_pauli_sum: PauliSum) -> 'Gate':
@@ -45,35 +52,28 @@ class Gate(ABC):
         Create a gate that maps input_pauli_sum to target_pauli_sum.
         """
 
-        input_symplectic = input_pauli_sum.tableau()
-        target_symplectic = target_pauli_sum.tableau()
-        symplectic = map_pauli_sum_to_target_tableau(input_symplectic, target_symplectic)
+        symplectic, phase_vector = find_map_to_target_pauli_sum(input_pauli_sum, target_pauli_sum)
 
-        return cls(name, symplectic.T)
+        return cls(name, symplectic.T, phase_vector)
 
     @classmethod
     def from_random(cls, n_qudits: int, n_transvection: int = 10, seed: int | None = None):
         if seed is not None:
             np.random.seed(seed)
         seed_vec = np.random.randint(0, 100000, size=n_transvection)
-        # if n_qudits < 4 and dimension == 2:
-        #     symp_int = np.random.randint(symplectic_group_size(n_qudits))
-        #     symplectic = symplectic_gf2(symp_int, n_qudits)
-        #     phase_vector = get_phase_vector(symplectic, dimension)
-        #     return cls(f"R{symp_int}", list(range(n_qudits)), symplectic.T, dimension, phase_vector)
-        # else:
         symplectic = np.eye(2 * n_qudits, dtype=int)
 
         for i in range(n_transvection):
             np.random.seed(seed_vec[i])
-            Tv = transvection_matrix(np.random.randint(0, dimension, size=2 * n_qudits), dimension) % dimension
-            symplectic = symplectic @ Tv % dimension
+            # NOTE: we take the modulo 193 to avoid generating a symplectic with too large entries.
+            #       Here 193 is some 'big' prime number.
+            Tv = transvection_matrix(np.random.randint(0, size=2 * n_qudits)) % 193
+            symplectic = symplectic @ Tv
 
-        phase_vector = get_phase_vector(symplectic, dimension)
-        return cls(f"R{n_transvection}", n_qudits, symplectic, phase_vector)
+        return cls(f"R{n_transvection}", symplectic)
 
     def __repr__(self):
-        return f"Gate(name={self.name}, n_qudits={self.n_qudits}, phase_vector={self.phase_vector})"
+        return f"Gate(name={self.name}, n_qudits={self._n_qudits}, phase_vector={self.phase_vector})"
 
     @overload
     def act(self, pauli: Pauli, qudit_indices: int | list[int]) -> Pauli:
@@ -112,11 +112,8 @@ class Gate(ABC):
         new_tableau = T.copy()
         new_tableau[:, tableau_mask] = updated_tableau
 
-        # FIXME: should we move this to a separate function?
-        # This is the part associated with the linear form.
-        phase_vector = Gate.get_phase_vector(pauli_dimensions)
-        modified_phase_vector = phase_vector - self.V_diag  # h - V_diag
-        linear_terms = T_affected @ modified_phase_vector
+        # FIXME: should we move the phase part to a separate function?
+        linear_terms = T_affected @ self.modified_phase_vector
         quadratic_terms = np.sum(T_affected * (T_affected @ self.p_part), axis=1)
 
         # FIXME: this is a but of a hack
@@ -137,9 +134,9 @@ class Gate(ABC):
             raise TypeError("Transvection weight must be an integer.")
 
         if isinstance(transvection_vector, list):
-            transvection_vector = np.array(transvection_vector)
+            transvection_vector = np.asarray(transvection_vector)
 
-        T = transvection_matrix(transvection_vector, multiplier=transvection_weight, p=dimension)
+        T = transvection_matrix(transvection_vector, multiplier=transvection_weight)
         if self.name[0] != "T":
             self.name = "T-" + self.name
         return Gate(self.name, self.symplectic @ T)
@@ -150,40 +147,40 @@ class Gate(ABC):
 
         C = self.symplectic.T
 
-        U = np.zeros((2 * self.n_qudits, 2 * self.n_qudits), dtype=int)
-        U[self.n_qudits:, :self.n_qudits] = np.eye(self.n_qudits, dtype=int)
-        Omega = symplectic_form(int(C.shape[0] / 2), p=self.lcm)
+        U = np.zeros((2 * self._n_qudits, 2 * self._n_qudits), dtype=int)
+        U[self._n_qudits:, :self._n_qudits] = np.eye(self._n_qudits, dtype=int)
+        Omega = symplectic_form(int(C.shape[0] / 2))
 
-        C_inv = -(Omega.T @ C.T @ Omega) % self.lcm
-        U_c = C_inv.T @ U @ C_inv % self.lcm
+        C_inv = -(Omega.T @ C.T @ Omega)
+        U_c = C_inv.T @ U @ C_inv
 
         p1 = - C_inv.T @ self.phase_vector
         p2 = - np.diag(C.T @ (2 * np.triu(U_c) - np.diag(np.diag(U_c))) @ C)
         p3 = C.T @ np.diag(U_c)
 
-        phase_vector = (p1 + p2 + p3) % (2 * self.lcm)
-        return Gate(self.name + "-inv", self.qudit_indices, C_inv.T, phase_vector)
+        phase_vector = (p1 + p2 + p3)
+        return Gate(self.name + "-inv", C_inv.T, phase_vector)
 
-    def inverse(self) -> 'Gate':
-        """
-        Returns the inverse of this gate.
+    # def inverse(self) -> 'Gate':
+    #     """
+    #     Returns the inverse of this gate.
 
-        The inverse of a gate G is another gate G' such that the composition G'G is the identity.
+    #     The inverse of a gate G is another gate G' such that the composition G'G is the identity.
 
-        The inverse of a gate is computed using the formulae presented in PHYSICAL REVIEW A 71, 042315 (2005)
+    #     The inverse of a gate is computed using the formulae presented in PHYSICAL REVIEW A 71, 042315 (2005)
 
-        :return: A new Gate object, the inverse of this gate.
-        """
-        n = self.n_qudits
-        Id_n = np.eye(n)
-        Zero_n = np.zeros((n, n))
-        U = np.block([[Zero_n, Zero_n], [Id_n, Zero_n]])
-        Omega = (U - U.T)
+    #     :return: A new Gate object, the inverse of this gate.
+    #     """
+    #     n = self._n_qudits
+    #     Id_n = np.eye(n)
+    #     Zero_n = np.zeros((n, n))
+    #     U = np.block([[Zero_n, Zero_n], [Id_n, Zero_n]])
+    #     Omega = (U - U.T)
 
-        C = self.symplectic.T
-        C_inv = Omega.T @ C.T @ Omega
+    #     C = self.symplectic.T
+    #     C_inv = Omega.T @ C.T @ Omega
 
-        return Gate(self.name + '_inv', C_inv.T)
+    #     return Gate(self.name + '_inv', C_inv.T)
 
     def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         raise NotImplementedError("Unitary not implemented for generic Gate. Use specific gate subclasses.")
@@ -199,10 +196,6 @@ class SUM(Gate):
         ], dtype=int).T
 
         super().__init__("SUM", symplectic)
-
-    @classmethod
-    def get_phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
-        return np.array([0, 0, 0, 0], dtype=int)
 
     def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         D = np.prod(dimensions)
@@ -224,9 +217,7 @@ class SWAP(Gate):
             [0, 0, 1, 0]   # image of Z1:  Z1 -> Z0
         ], dtype=int).T
 
-        phase_vector = np.array([0, 0, 0, 0], dtype=int)
-
-        super().__init__("SWAP", 2, symplectic, phase_vector=phase_vector)
+        super().__init__("SWAP", symplectic)
 
     def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         # SWAP on two qudits of equal dimension: |i, j> -> |j, i>.
@@ -242,7 +233,7 @@ class SWAP(Gate):
         return sp.csr_matrix((aa2, (aa3, aa4)))
 
     @staticmethod
-    def _swap_linear_index(i, a0, a1, dims):
+    def _swap_linear_index(i: int, a0, a1, dims) -> int:
         # Convert linear index i to multi-index in row-major order
         multi_idx = []
         rem = i
@@ -261,30 +252,6 @@ class SWAP(Gate):
         return idx
 
 
-class CNOT(Gate):
-    def __init__(self):
-        symplectic = np.array([
-            [1, 1, 0, 0],   # image of X0:  X0 -> X0 X1
-            [0, 1, 0, 0],   # image of X1:  X1 -> X1
-            [0, 0, 1, 0],   # image of Z0:  Z0 -> Z0
-            [0, 0, 1, 1]   # image of Z1:  Z1 -> Z0^-1 Z1
-        ], dtype=int).T
-
-        phase_vector = np.array([0, 0, 0, 0], dtype=int)
-
-        super().__init__("SUM", 2, symplectic, phase_vector=phase_vector)
-
-    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
-        D = np.prod(dimensions)
-        aa = qudit_indices
-        a0 = aa[0]
-        a1 = aa[1]
-        aa2 = np.array([1 for i in range(D)])
-        aa3 = np.array([CX_func(i, a0, a1, dimensions) for i in range(D)])
-        aa4 = np.array([i for i in range(D)])
-        return sp.csr_matrix((aa2, (aa3, aa4)))
-
-
 class Hadamard(Gate):
     def __init__(self, inverse: bool = False):
         if inverse:
@@ -298,10 +265,8 @@ class Hadamard(Gate):
                 [1, 0]     # image of Z:  Z -> X
             ], dtype=int)
 
-        phase_vector = np.array([0, 0], dtype=int)
-
         name = "H" if not inverse else "H_inv"
-        super().__init__(name, 1, symplectic, phase_vector=phase_vector)
+        super().__init__(name, symplectic)
 
     def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         return tensor(
@@ -316,15 +281,14 @@ class PHASE(Gate):
             [0, 1]   # image of Z:  Z -> Z
         ], dtype=int).T
 
-        super().__init__("S", 1, symplectic)
+        super().__init__("S", symplectic)
 
     @classmethod
-    def get_phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
+    def phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
         if dimensions == 2:
-            phase_vector = np.array([1, 0], dtype=int)
-        else:
-            phase_vector = np.array([0, 0], dtype=int)
-        return super().get_phase_vector()
+            return np.array([1, 0], dtype=int)
+
+        return np.array([0, 0], dtype=int)
 
     def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         unitary = tensor([S_mat(dimensions[i]) if i in qudit_indices else I_mat(dimensions[i])
@@ -336,7 +300,6 @@ class _Gates():
     def __init__(self):
         self._sum = SUM()
         self._swap = SWAP()
-        self._cnot = CNOT()
         self._hadamard = Hadamard()
         self._phase = PHASE()
 
@@ -354,7 +317,7 @@ class _Gates():
 
     @property
     def cnot(self):
-        return self._cnot
+        return self._sum
 
     @property
     def hadamard(self):

--- a/src/sympleq/core/circuits/gates.py
+++ b/src/sympleq/core/circuits/gates.py
@@ -1,9 +1,9 @@
 from abc import ABC
 import numpy as np
 import scipy.sparse as sp
-from typing import TypeVar, overload
+from typing import TypeVar
 
-from sympleq.core.paulis import Pauli, PauliString, PauliSum, PauliObject
+from sympleq.core.paulis import PauliSum, PauliObject
 from sympleq.core.circuits.target import find_map_to_target_pauli_sum
 from sympleq.core.circuits.utils import transvection_matrix, symplectic_form, tensor, I_mat, H_mat, S_mat, CX_func
 
@@ -19,18 +19,18 @@ P = TypeVar("P", bound="PauliObject")
 
 class Gate(ABC):
     def __init__(self, name: str, symplectic: np.ndarray, phase_vector: np.ndarray):
-        self.name = name
+        self._name = name
         n_qudits = symplectic.shape[0] // 2
         self._n_qudits = n_qudits
-        self.symplectic = symplectic
+        self._symplectic = symplectic
 
-        self.phase_vector = phase_vector
+        self._phase_vector = phase_vector
 
         # U = [[0_n, 0_n],
         #      [I_n, 0_n]]
         U = np.zeros((2 * self._n_qudits, 2 * self._n_qudits), dtype=int)
         U[self._n_qudits:, :self._n_qudits] = np.eye(self._n_qudits, dtype=int)
-        self.U_symplectic_conjugated = self.symplectic.T @ U @ self.symplectic
+        self.U_symplectic_conjugated = self._symplectic.T @ U @ self._symplectic
 
         self.V_diag = np.diag(self.U_symplectic_conjugated)
 
@@ -40,9 +40,6 @@ class Gate(ABC):
         # This is the part associated with the quadratic form.
         # We remove diagonal part to match definition in Eq.[7] in PHYSICAL REVIEW A 71, 042315 (2005).
         self.p_part = 2 * np.triu(self.U_symplectic_conjugated) - np.diag(self.V_diag)
-
-    def n_qudits(self) -> int:
-        return self._n_qudits
 
     @classmethod
     def solve_from_target(cls, name: str, input_pauli_sum: PauliSum, target_pauli_sum: PauliSum) -> 'Gate':
@@ -69,8 +66,20 @@ class Gate(ABC):
 
         return cls(f"R{n_transvection}", symplectic, np.zeros(len(symplectic)))
 
+    def name(self) -> str:
+        return self._name
+
+    def n_qudits(self) -> int:
+        return self._n_qudits
+
+    def phase_vector(self) -> np.ndarray:
+        return self._phase_vector
+
+    def symplectic(self) -> np.ndarray:
+        return self._symplectic
+
     def __repr__(self):
-        return f"Gate(name={self.name}, n_qudits={self._n_qudits}, phase_vector={self.phase_vector})"
+        return f"Gate(name={self._name}, n_qudits={self._n_qudits}, phase_vector={self._phase_vector})"
 
     # @overload
     # def act(self, pauli: Pauli, qudits: int | list[int] | np.ndarray | tuple[int, ...]) -> Pauli:
@@ -84,26 +93,27 @@ class Gate(ABC):
     # def act(self, pauli: PauliSum, qudits: int | list[int] | np.ndarray | tuple[int, ...]) -> PauliSum:
     #     ...
 
-    def act(self, pauli: P, *qudits: int) -> P:
+    def act(self, pauli: P, qudits: int | tuple[int, ...]) -> P:
         """
         Returns the updated tableau and phases acquired by the PauliSum when acted upon by this gate.
 
         See Eq.[7] in PHYSICAL REVIEW A 71, 042315 (2005)
 
         """
+        if isinstance(qudits, int):
+            qudits = (qudits, )
 
         affected_qudits = np.asarray(qudits, dtype=int)
         T = pauli.tableau()
 
         # Precompute tableau mask. This will be applied to the PauliSum tableau to get
         # the subset of affected columns.
-        tableau_mask = np.concatenate([affected_qudits, affected_qudits + pauli.n_qudits()])
-
+        tableau_mask = np.concatenate([affected_qudits, affected_qudits + pauli.n_qudits()], dtype=int)
         T_affected = T[:, tableau_mask]
 
         pauli_dimensions = pauli.dimensions()[affected_qudits]
         relevant_dimensions = np.tile(pauli_dimensions, 2)
-        updated_tableau = np.mod(T_affected @ self.symplectic.T, relevant_dimensions)
+        updated_tableau = np.mod(T_affected @ self._symplectic.T, relevant_dimensions)
         new_tableau = T.copy()
         new_tableau[:, tableau_mask] = updated_tableau
 
@@ -132,18 +142,18 @@ class Gate(ABC):
             transvection_vector = np.asarray(transvection_vector)
 
         T = transvection_matrix(transvection_vector, multiplier=transvection_weight)
-        if self.name[0] != "T":
-            self.name = "T-" + self.name
+        if self.name()[0] != "T":
+            self._name = "T-" + self.name()
 
         # FIXME: generate correct phase_vector
-        phase_vector = np.zeros(len(self.symplectic))
-        return Gate(self.name, self.symplectic @ T, phase_vector)
+        phase_vector = np.zeros(len(self._symplectic))
+        return Gate(self.name(), self.symplectic @ T, phase_vector)
 
     def inverse(self) -> 'Gate':
         # TODO: Test for mixed dimensions - not clear that the symplectic form here is correct.
         print("Warning: inverse phase vector not working - PHASES MAY BE INCORRECT.")
 
-        C = self.symplectic.T
+        C = self._symplectic.T
 
         U = np.zeros((2 * self._n_qudits, 2 * self._n_qudits), dtype=int)
         U[self._n_qudits:, :self._n_qudits] = np.eye(self._n_qudits, dtype=int)
@@ -157,9 +167,9 @@ class Gate(ABC):
         p3 = C.T @ np.diag(U_c)
 
         phase_vector = (p1 + p2 + p3)
-        return Gate(self.name + "-inv", C_inv.T, phase_vector)
+        return Gate(self.name() + "-inv", C_inv.T, phase_vector)
 
-    def unitary(self, qudits: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
         raise NotImplementedError("Unitary not implemented for generic Gate. Use specific gate subclasses.")
 
 
@@ -174,11 +184,13 @@ class SUM(Gate):
 
         super().__init__("SUM", symplectic, np.zeros(len(symplectic)))
 
-    def unitary(self, qudits: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
         D = np.prod(dimensions)
-        aa = qudits
-        a0 = aa[0]
-        a1 = aa[1]
+        if isinstance(qudits, int):
+            qudits = [qudits]
+
+        a0 = qudits[0]
+        a1 = qudits[1]
         aa2 = np.array([1 for i in range(D)])
         aa3 = np.array([CX_func(i, a0, a1, dimensions) for i in range(D)])
         aa4 = np.array([i for i in range(D)])
@@ -196,37 +208,37 @@ class SWAP(Gate):
 
         super().__init__("SWAP", symplectic, np.zeros(len(symplectic)))
 
-    def unitary(self, qudits: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
         # SWAP on two qudits of equal dimension: |i, j> -> |j, i>.
         # Basis ordering |i>⊗|j> with linear index idx(i, j) = i * d + j.
-        aa = qudits
+        # normalize inputs
+        if isinstance(qudits, int):
+            qudits = (qudits,)
+
+        if len(qudits) != 2:
+            raise ValueError("SWAP gate requires exactly two qudits.")
         q = len(dimensions)
-        D = np.prod(dimensions)
-        a0 = q - 1 - aa[0]
-        a1 = q - 1 - aa[1]
-        aa2 = np.array([1 for i in range(D)])
-        aa3 = np.array([i for i in range(D)])
-        aa4 = np.array([SWAP._swap_linear_index(i, a0, a1, dimensions) for i in range(D)])
-        return sp.csr_matrix((aa2, (aa3, aa4)))
+        D = int(np.prod(dimensions))
 
-    @staticmethod
-    def _swap_linear_index(i: int, a0, a1, dims) -> int:
-        # Convert linear index i to multi-index in row-major order
-        multi_idx = []
-        rem = i
-        for d in reversed(dims):
-            multi_idx.append(rem % d)
-            rem //= d
-        multi_idx = multi_idx[::-1]
+        if any(not (0 <= qi < q) for qi in qudits):
+            raise IndexError("qudit index out of range")
 
-        # Swap the two qudits
-        multi_idx[a0], multi_idx[a1] = multi_idx[a1], multi_idx[a0]
+        # Create array of linear indices shaped by the tensor-product ordering
+        # shape = (d0, d1, ..., d_{q-1}), row-major ordering
+        indices = np.arange(D).reshape(*dimensions)
 
-        # Convert back to linear index (row-major)
-        idx = 0
-        for j, dim in enumerate(dims):
-            idx = idx * dim + multi_idx[j]
-        return idx
+        # swap the axes corresponding to the two qudits
+        a0, a1 = qudits
+        swapped = np.swapaxes(indices, a0, a1)
+
+        # flattened column indices after swap
+        aa3 = np.arange(D, dtype=int)        # rows: original linear indices
+        aa4 = swapped.ravel()                # columns: where basis state i moves to
+        aa2 = np.ones(D, dtype=int)          # ones for permutation matrix
+
+        m = sp.csr_matrix((aa2, (aa3, aa4)), shape=(D, D))
+        assert m.shape == (D, D)
+        return m
 
 
 class Hadamard(Gate):
@@ -244,14 +256,12 @@ class Hadamard(Gate):
 
         name = "H" if not inverse else "H_inv"
 
-        # FIXME: get correct phase_vector
         super().__init__(name, symplectic, np.zeros(len(symplectic)))
 
-    def unitary(self, qudits: int | list[int], dimensions: int | list[int] | np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
         if isinstance(qudits, int):
             qudits = [qudits]
-        if isinstance(dimensions, int):
-            dimensions = [dimensions]
+
         return tensor(
             [H_mat(dimensions[i]) if i in qudits else I_mat(dimensions[i]) for i in range(len(dimensions))]
         )
@@ -266,14 +276,16 @@ class PHASE(Gate):
 
         super().__init__("S", symplectic, np.zeros(len(symplectic)))
 
-    @classmethod
-    def phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
-        if dimensions == 2:
-            return np.array([1, 0], dtype=int)
+    # @classmethod
+    # def phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
+    #     if dimensions == 2:
+    #         return np.array([1, 0], dtype=int)
 
-        return np.array([0, 0], dtype=int)
+    #     return np.array([0, 0], dtype=int)
 
-    def unitary(self, qudits: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
+        if isinstance(qudits, int):
+            qudits = [qudits]
         unitary = tensor([S_mat(dimensions[i]) if i in qudits else I_mat(dimensions[i])
                          for i in range(len(dimensions))])
         return unitary

--- a/src/sympleq/core/circuits/gates.py
+++ b/src/sympleq/core/circuits/gates.py
@@ -1,43 +1,24 @@
+from abc import ABC
 import numpy as np
 import scipy.sparse as sp
 from typing import TypeVar, overload
 
+from sympleq.core.circuits.find_symplectic import map_pauli_sum_to_target_tableau
 from sympleq.core.paulis import Pauli, PauliString, PauliSum, PauliObject
-from sympleq.core.circuits.target import find_map_to_target_pauli_sum, get_phase_vector
+from sympleq.core.circuits.target import get_phase_vector
 from sympleq.core.circuits.utils import transvection_matrix, symplectic_form, tensor, I_mat, H_mat, S_mat, CX_func
-from sympleq.utils import get_linear_dependencies
 
 # We define a type using TypeVar to let the type checker know that
 # the input and output of the `act` function share the same type.
 P = TypeVar("P", bound="PauliObject")
 
 
-class Gate:
-    def __init__(self, name: str,
-                 qudit_indices: list[int] | np.ndarray,
-                 symplectic: np.ndarray,
-                 dimensions: int | list[int] | np.ndarray,
-                 phase_vector: np.ndarray | list[int]):
-
-        if len(qudit_indices) == 0:
-            raise ValueError("Gate must act on at least one qudit_indices.")
-
-        if isinstance(dimensions, int) or isinstance(dimensions, np.signedinteger):
-            dimensions = dimensions * np.ones(len(qudit_indices), dtype=int)
-        elif len(qudit_indices) != len(dimensions):
-            raise ValueError("Dimensions and qudit_indices must have the same length.")
-
-        self.dimensions = dimensions
+class Gate(ABC):
+    def __init__(self, name: str, symplectic: np.ndarray):
         self.name = name
-
-        if isinstance(qudit_indices, list):
-            qudit_indices = np.asarray(qudit_indices, dtype=int)
-
-        self.qudit_indices = qudit_indices
-        self.n_qudits = len(qudit_indices)
-        self.symplectic: np.ndarray = symplectic
-        self.phase_vector = phase_vector
-        self.lcm = np.lcm.reduce(self.dimensions)
+        n_qudits = len(symplectic) // 2
+        self._n_qudits = n_qudits
+        self.symplectic = symplectic
 
         # U = [[0_n, 0_n],
         #      [I_n, 0_n]]
@@ -46,30 +27,32 @@ class Gate:
         self.U_symplectic_conjugated = self.symplectic.T @ U @ self.symplectic
 
         self.V_diag = np.diag(self.U_symplectic_conjugated)
-        # This is the part associated with the linear form.
-        self.modified_phase_vector = self.phase_vector - self.V_diag  # h - V_diag
-        # Remove diagonal part to match definition in Eq.[7] in PHYSICAL REVIEW A 71, 042315 (2005).
         # This is the part associated with the quadratic form.
+        # We remove diagonal part to match definition in Eq.[7] in PHYSICAL REVIEW A 71, 042315 (2005).
         self.p_part = 2 * np.triu(self.U_symplectic_conjugated) - np.diag(self.V_diag)
 
     @classmethod
-    def solve_from_target(cls, name: str, input_pauli_sum: PauliSum, target_pauli_sum: PauliSum,
-                          dimensions: int | list[int] | np.ndarray):
+    def get_phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    @abstractmethod
+    def n_qudits(self) -> int:
+        pass
+
+    @classmethod
+    def solve_from_target(cls, name: str, input_pauli_sum: PauliSum, target_pauli_sum: PauliSum) -> 'Gate':
         """
         Create a gate that maps input_pauli_sum to target_pauli_sum.
         """
 
-        independent_set, dependent_set = get_linear_dependencies(input_pauli_sum.tableau(), dimensions)
+        input_symplectic = input_pauli_sum.tableau()
+        target_symplectic = target_pauli_sum.tableau()
+        symplectic = map_pauli_sum_to_target_tableau(input_symplectic, target_symplectic)
 
-        if len(dependent_set) != 0:
-            raise NotImplementedError("Input PauliSum is not linearly independent. Will be implemented dreckly.")
-
-        symplectic, phase_vector, qudit_indices, dimension = find_map_to_target_pauli_sum(input_pauli_sum,
-                                                                                          target_pauli_sum)
-        return cls(name, qudit_indices, symplectic.T, dimension, phase_vector)
+        return cls(name, symplectic.T)
 
     @classmethod
-    def from_random(cls, n_qudits: int, dimension: int, n_transvection: int = 10, seed: int | None = None):
+    def from_random(cls, n_qudits: int, n_transvection: int = 10, seed: int | None = None):
         if seed is not None:
             np.random.seed(seed)
         seed_vec = np.random.randint(0, 100000, size=n_transvection)
@@ -87,52 +70,57 @@ class Gate:
             symplectic = symplectic @ Tv % dimension
 
         phase_vector = get_phase_vector(symplectic, dimension)
-        return cls(f"R{n_transvection}", list(range(n_qudits)), symplectic, dimension, phase_vector)
+        return cls(f"R{n_transvection}", n_qudits, symplectic, phase_vector)
 
     def __repr__(self):
-        return f"Gate(name={self.name}, qudit_indices={self.qudit_indices}, " \
-            f"dimensions={self.dimensions}, phase_vector={self.phase_vector})"
+        return f"Gate(name={self.name}, n_qudits={self.n_qudits}, phase_vector={self.phase_vector})"
 
     @overload
-    def act(self, pauli: Pauli) -> Pauli:
+    def act(self, pauli: Pauli, qudit_indices: int | list[int]) -> Pauli:
         ...
 
     @overload
-    def act(self, pauli: PauliString) -> PauliString:
+    def act(self, pauli: PauliString, qudit_indices: int | list[int]) -> PauliString:
         ...
 
     @overload
-    def act(self, pauli: PauliSum) -> PauliSum:
+    def act(self, pauli: PauliSum, qudit_indices: int | list[int]) -> PauliSum:
         ...
 
-    def act(self, pauli: P) -> P:
+    def act(self, pauli: P, qudit_indices: int | list[int] | np.ndarray) -> P:
         """
         Returns the updated tableau and phases acquired by the PauliSum when acted upon by this gate.
 
         See Eq.[7] in PHYSICAL REVIEW A 71, 042315 (2005)
 
         """
-        if not np.array_equal(self.dimensions, pauli.dimensions()[self.qudit_indices]):
-            raise ValueError("Gate and Pauli object have different dimensions.")
+        if isinstance(qudit_indices, int):
+            qudit_indices = [qudit_indices]
+        qudit_indices = np.asarray(qudit_indices, dtype=int)
+
+        pauli_dimensions = pauli.dimensions()[qudit_indices]
 
         T = pauli.tableau()
 
         # Precompute tableau mask. This will be applied to the PauliSum tableau to get
         # the subset of affected columns.
-        tableau_mask = np.concatenate([self.qudit_indices, self.qudit_indices + pauli.n_qudits()])
+        tableau_mask = np.concatenate([qudit_indices, qudit_indices + pauli.n_qudits()])
 
         T_affected = T[:, tableau_mask]
-        relevant_dimensions = np.tile(pauli.dimensions()[self.qudit_indices], 2)
+        relevant_dimensions = np.tile(pauli_dimensions, 2)
         updated_tableau = np.mod(T_affected @ self.symplectic.T, relevant_dimensions)
         new_tableau = T.copy()
         new_tableau[:, tableau_mask] = updated_tableau
 
         # FIXME: should we move this to a separate function?
-        linear_terms = T_affected @ self.modified_phase_vector
+        # This is the part associated with the linear form.
+        phase_vector = Gate.get_phase_vector(pauli_dimensions)
+        modified_phase_vector = phase_vector - self.V_diag  # h - V_diag
+        linear_terms = T_affected @ modified_phase_vector
         quadratic_terms = np.sum(T_affected * (T_affected @ self.p_part), axis=1)
 
         # FIXME: this is a but of a hack
-        dimensional_factor = pauli.lcm() // np.lcm.reduce(pauli.dimensions()[self.qudit_indices])
+        dimensional_factor = pauli.lcm() // np.lcm.reduce(pauli.dimensions()[qudit_indices])
         acquired_phases = (linear_terms + quadratic_terms) * dimensional_factor
 
         new_phases = (pauli.phases() + acquired_phases) % (2 * pauli.lcm())
@@ -140,32 +128,21 @@ class Gate:
         return pauli.__class__(tableau=new_tableau, dimensions=pauli.dimensions(),
                                weights=pauli.weights(), phases=new_phases)
 
-    def copy(self) -> 'Gate':
-        """
-        Returns a copy of the gate.
-        """
-        return Gate(self.name, self.qudit_indices.copy(), self.symplectic.copy(), self.dimensions,
-                    self.phase_vector.copy())
-
     def transvection(self, transvection_vector: np.ndarray | list, transvection_weight: int = 1) -> 'Gate':
         """
         Returns a new gate that is the transvection of this gate by the given vector.
         The transvection vector should be a 2n-dimensional vector where n is the number of qudits.
         """
-        if not np.all(self.dimensions == self.dimensions[0]):
-            raise ValueError("Transvections only implemented for gates with equal dimensions.")
-        dimension = self.dimensions[0]
-        if transvection_weight >= dimension:
-            raise ValueError("Transvection weight must be less than the gate dimension.")
         if not isinstance(transvection_weight, int) and not isinstance(transvection_weight, np.int64):
             raise TypeError("Transvection weight must be an integer.")
+
         if isinstance(transvection_vector, list):
             transvection_vector = np.array(transvection_vector)
 
         T = transvection_matrix(transvection_vector, multiplier=transvection_weight, p=dimension)
         if self.name[0] != "T":
             self.name = "T-" + self.name
-        return Gate(self.name, self.qudit_indices, self.symplectic @ T, self.dimensions, self.phase_vector)
+        return Gate(self.name, self.symplectic @ T)
 
     def inv(self) -> 'Gate':
         # TODO: Test for mixed dimensions - not clear that the symplectic form here is correct.
@@ -185,7 +162,7 @@ class Gate:
         p3 = C.T @ np.diag(U_c)
 
         phase_vector = (p1 + p2 + p3) % (2 * self.lcm)
-        return Gate(self.name + "-inv", self.qudit_indices, C_inv.T, self.dimensions, phase_vector)
+        return Gate(self.name + "-inv", self.qudit_indices, C_inv.T, phase_vector)
 
     def inverse(self) -> 'Gate':
         """
@@ -197,38 +174,23 @@ class Gate:
 
         :return: A new Gate object, the inverse of this gate.
         """
-        if not np.all(self.dimensions == self.dimensions[0]):
-            raise NotImplementedError("Inverse only implemented for gates with equal dimensions.")
-
-        d = self.dimensions[0]
-        h = self.phase_vector
-        n = len(self.qudit_indices)
-
+        n = self.n_qudits
         Id_n = np.eye(n)
         Zero_n = np.zeros((n, n))
         U = np.block([[Zero_n, Zero_n], [Id_n, Zero_n]])
-        Omega = (U - U.T) % d
+        Omega = (U - U.T)
 
         C = self.symplectic.T
-        C_inv = (Omega.T @ C.T @ Omega) % d
+        C_inv = Omega.T @ C.T @ Omega
 
-        U_trans = C_inv.T @ U @ C_inv
-        T1 = np.diag(C.T @ (2 * np.triu(U_trans, k=1) + np.diag(np.diag(U_trans))) @ C)
-        T2 = C.T @ np.diag(U_trans)
+        return Gate(self.name + '_inv', C_inv.T)
 
-        h_inv = (- C_inv.T @ (h + T1 + T2)) % (2 * d)
-
-        return Gate(self.name + '_inv', self.qudit_indices.copy(), C_inv.T, self.dimensions,
-                    h_inv)
-
-    def unitary(self, dims=None) -> sp.csr_matrix:
-        if dims is None:
-            dims = self.dimensions
+    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         raise NotImplementedError("Unitary not implemented for generic Gate. Use specific gate subclasses.")
 
 
 class SUM(Gate):
-    def __init__(self, control, target, dimension):
+    def __init__(self):
         symplectic = np.array([
             [1, 1, 0, 0],   # image of X0:  X0 -> X0 X1
             [0, 1, 0, 0],   # image of X1:  X1 -> X1
@@ -236,31 +198,25 @@ class SUM(Gate):
             [0, 0, -1, 1]   # image of Z1:  Z1 -> Z0^-1 Z1
         ], dtype=int).T
 
-        phase_vector = np.array([0, 0, 0, 0], dtype=int)
+        super().__init__("SUM", symplectic)
 
-        super().__init__("SUM", [control, target], symplectic, dimensions=dimension, phase_vector=phase_vector)
+    @classmethod
+    def get_phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
+        return np.array([0, 0, 0, 0], dtype=int)
 
-    def unitary(self, dims=None) -> sp.csr_matrix:
-        if dims is None:
-            dims = self.dimensions
-        D = np.prod(dims)
-        aa = self.qudit_indices
+    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+        D = np.prod(dimensions)
+        aa = qudit_indices
         a0 = aa[0]
         a1 = aa[1]
         aa2 = np.array([1 for i in range(D)])
-        aa3 = np.array([CX_func(i, a0, a1, dims) for i in range(D)])
+        aa3 = np.array([CX_func(i, a0, a1, dimensions) for i in range(D)])
         aa4 = np.array([i for i in range(D)])
         return sp.csr_matrix((aa2, (aa3, aa4)))
 
-    def copy(self) -> 'Gate':
-        """
-        Returns a copy of the SUM gate.
-        """
-        return SUM(self.qudit_indices[0], self.qudit_indices[1], self.dimensions)
-
 
 class SWAP(Gate):
-    def __init__(self, index1, index2, dimension):
+    def __init__(self):
         symplectic = np.array([
             [0, 1, 0, 0],  # image of X0:  X0 -> X1
             [1, 0, 0, 0],  # image of X1:  X1 -> X0
@@ -270,28 +226,20 @@ class SWAP(Gate):
 
         phase_vector = np.array([0, 0, 0, 0], dtype=int)
 
-        super().__init__("SWAP", [index1, index2], symplectic, dimensions=dimension, phase_vector=phase_vector)
+        super().__init__("SWAP", 2, symplectic, phase_vector=phase_vector)
 
-    def unitary(self, dims=None) -> sp.csr_matrix:
+    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         # SWAP on two qudits of equal dimension: |i, j> -> |j, i>.
         # Basis ordering |i>⊗|j> with linear index idx(i, j) = i * d + j.
-        if dims is None:
-            dims = self.dimensions
-        aa = self.qudit_indices
-        q = len(dims)
-        D = np.prod(dims)
+        aa = qudit_indices
+        q = len(dimensions)
+        D = np.prod(dimensions)
         a0 = q - 1 - aa[0]
         a1 = q - 1 - aa[1]
         aa2 = np.array([1 for i in range(D)])
         aa3 = np.array([i for i in range(D)])
-        aa4 = np.array([SWAP._swap_linear_index(i, a0, a1, dims) for i in range(D)])
+        aa4 = np.array([SWAP._swap_linear_index(i, a0, a1, dimensions) for i in range(D)])
         return sp.csr_matrix((aa2, (aa3, aa4)))
-
-    def copy(self) -> 'Gate':
-        """
-        Returns a copy of the SWAP gate.
-        """
-        return SWAP(self.qudit_indices[0], self.qudit_indices[1], self.dimensions)
 
     @staticmethod
     def _swap_linear_index(i, a0, a1, dims):
@@ -314,7 +262,7 @@ class SWAP(Gate):
 
 
 class CNOT(Gate):
-    def __init__(self, control, target):
+    def __init__(self):
         symplectic = np.array([
             [1, 1, 0, 0],   # image of X0:  X0 -> X0 X1
             [0, 1, 0, 0],   # image of X1:  X1 -> X1
@@ -324,29 +272,21 @@ class CNOT(Gate):
 
         phase_vector = np.array([0, 0, 0, 0], dtype=int)
 
-        super().__init__("SUM", [control, target], symplectic, dimensions=2, phase_vector=phase_vector)
+        super().__init__("SUM", 2, symplectic, phase_vector=phase_vector)
 
-    def unitary(self, dims=None) -> sp.csr_matrix:
-        if dims is None:
-            dims = self.dimensions
-        D = np.prod(dims)
-        aa = self.qudit_indices
+    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+        D = np.prod(dimensions)
+        aa = qudit_indices
         a0 = aa[0]
         a1 = aa[1]
         aa2 = np.array([1 for i in range(D)])
-        aa3 = np.array([CX_func(i, a0, a1, dims) for i in range(D)])
+        aa3 = np.array([CX_func(i, a0, a1, dimensions) for i in range(D)])
         aa4 = np.array([i for i in range(D)])
         return sp.csr_matrix((aa2, (aa3, aa4)))
 
-    def copy(self) -> 'Gate':
-        """
-        Returns a copy of the CNOT gate.
-        """
-        return CNOT(self.qudit_indices[0], self.qudit_indices[1])
-
 
 class Hadamard(Gate):
-    def __init__(self, index: int, dimension: int, inverse: bool = False):
+    def __init__(self, inverse: bool = False):
         if inverse:
             symplectic = np.array([
                 [0, 1],    # image of X:  X -> Z
@@ -361,46 +301,76 @@ class Hadamard(Gate):
         phase_vector = np.array([0, 0], dtype=int)
 
         name = "H" if not inverse else "H_inv"
-        super().__init__(name, [index], symplectic, dimensions=dimension, phase_vector=phase_vector)
+        super().__init__(name, 1, symplectic, phase_vector=phase_vector)
 
-    def unitary(self, dims=None) -> sp.csr_matrix:
-        if dims is None:
-            dims = self.dimensions
-
+    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         return tensor(
-            [H_mat(dims[i]) if i in self.qudit_indices else I_mat(dims[i]) for i in range(len(dims))]
+            [H_mat(dimensions[i]) if i in qudit_indices else I_mat(dimensions[i]) for i in range(len(dimensions))]
         )
-
-    def copy(self) -> 'Gate':
-        """
-        Returns a copy of the Hadamard gate.
-        """
-        return Hadamard(self.qudit_indices[0], self.dimensions[0])
 
 
 class PHASE(Gate):
-
-    def __init__(self, index: int, dimension: int):
+    def __init__(self):
         symplectic = np.array([
             [1, 1],  # image of X:  X -> XZ
             [0, 1]   # image of Z:  Z -> Z
         ], dtype=int).T
-        if dimension == 2:
+
+        super().__init__("S", 1, symplectic)
+
+    @classmethod
+    def get_phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
+        if dimensions == 2:
             phase_vector = np.array([1, 0], dtype=int)
         else:
             phase_vector = np.array([0, 0], dtype=int)
+        return super().get_phase_vector()
 
-        super().__init__("S", [index], symplectic, dimensions=dimension, phase_vector=phase_vector)
-
-    def unitary(self, dims=None) -> sp.csr_matrix:
-        if dims is None:
-            dims = self.dimensions
-
-        unitary = tensor([S_mat(dims[i]) if i in self.qudit_indices else I_mat(dims[i]) for i in range(len(dims))])
+    def unitary(self, qudit_indices: list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
+        unitary = tensor([S_mat(dimensions[i]) if i in qudit_indices else I_mat(dimensions[i])
+                         for i in range(len(dimensions))])
         return unitary
 
-    def copy(self) -> 'Gate':
-        """
-        Returns a copy of the PHASE gate.
-        """
-        return PHASE(self.qudit_indices[0], self.dimensions[0])
+
+class _Gates():
+    def __init__(self):
+        self._sum = SUM()
+        self._swap = SWAP()
+        self._cnot = CNOT()
+        self._hadamard = Hadamard()
+        self._phase = PHASE()
+
+    @property
+    def sum(self):
+        return self._sum
+
+    @property
+    def CX(self):
+        return self._sum
+
+    @property
+    def swap(self):
+        return self._swap
+
+    @property
+    def cnot(self):
+        return self._cnot
+
+    @property
+    def hadamard(self):
+        return self._hadamard
+
+    @property
+    def H(self):
+        return self._hadamard
+
+    @property
+    def phase(self):
+        return self._phase
+
+    @property
+    def S(self):
+        return self._phase
+
+
+GATES = _Gates()

--- a/src/sympleq/core/circuits/gates.py
+++ b/src/sympleq/core/circuits/gates.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
 from abc import ABC
 import numpy as np
 import scipy.sparse as sp
 from typing import TypeVar
 
+from sympleq.core.paulis.constants import DEFAULT_QUDIT_DIMENSION
 from sympleq.core.paulis import PauliSum, PauliObject
 from sympleq.core.circuits.target import find_map_to_target_pauli_sum
-from sympleq.core.circuits.utils import transvection_matrix, symplectic_form, tensor, I_mat, H_mat, S_mat, CX_func
+from sympleq.core.circuits.utils import transvection_matrix, symplectic_form, tensor, I_mat, H_mat, S_mat
 
 # We define a type using TypeVar to let the type checker know that
 # the input and output of the `act` function share the same type.
@@ -18,13 +20,17 @@ P = TypeVar("P", bound="PauliObject")
 
 
 class Gate(ABC):
-    def __init__(self, name: str, symplectic: np.ndarray, phase_vector: np.ndarray):
+    def __init__(self, name: str, symplectic: np.ndarray,
+                 phase_vector: np.ndarray | None = None, exceptional_phase_vectors: dict[int, np.ndarray] = {}):
         self._name = name
         n_qudits = symplectic.shape[0] // 2
         self._n_qudits = n_qudits
         self._symplectic = symplectic
 
-        self._phase_vector = phase_vector
+        if phase_vector is None:
+            phase_vector = np.zeros(len(symplectic), dtype=int)
+        self._phase_vectors = exceptional_phase_vectors.copy()
+        self._phase_vectors[0] = phase_vector  # Default entry
 
         # U = [[0_n, 0_n],
         #      [I_n, 0_n]]
@@ -33,16 +39,12 @@ class Gate(ABC):
         self.U_symplectic_conjugated = self._symplectic.T @ U @ self._symplectic
 
         self.V_diag = np.diag(self.U_symplectic_conjugated)
-
-        # This is the part associated with the linear form.
-        self.modified_phase_vector = phase_vector - self.V_diag  # h - V_diag
-
         # This is the part associated with the quadratic form.
         # We remove diagonal part to match definition in Eq.[7] in PHYSICAL REVIEW A 71, 042315 (2005).
         self.p_part = 2 * np.triu(self.U_symplectic_conjugated) - np.diag(self.V_diag)
 
     @classmethod
-    def solve_from_target(cls, name: str, input_pauli_sum: PauliSum, target_pauli_sum: PauliSum) -> 'Gate':
+    def solve_from_target(cls, name: str, input_pauli_sum: PauliSum, target_pauli_sum: PauliSum) -> Gate:
         """
         Create a gate that maps input_pauli_sum to target_pauli_sum.
         """
@@ -52,7 +54,12 @@ class Gate(ABC):
         return cls(name, symplectic.T, phase_vector)
 
     @classmethod
-    def from_random(cls, n_qudits: int, n_transvection: int = 10, seed: int | None = None):
+    def from_random(cls, n_qudits: int, n_transvection: int = 10,
+                    seed: int | None = None, max_transvection_value: int = 7):
+
+        if max_transvection_value < DEFAULT_QUDIT_DIMENSION:
+            raise ValueError(f"Max value for transvection vector should be {DEFAULT_QUDIT_DIMENSION}.")
+
         if seed is not None:
             np.random.seed(seed)
         seed_vec = np.random.randint(0, 100000, size=n_transvection)
@@ -61,7 +68,7 @@ class Gate(ABC):
         for i in range(n_transvection):
             np.random.seed(seed_vec[i])
             # FIXME: Check if we should take some intermediary modulo operation to keep matrix small.
-            Tv = transvection_matrix(np.random.randint(0, size=2 * n_qudits))
+            Tv = transvection_matrix(np.random.randint(0, max_transvection_value, size=2 * n_qudits))
             symplectic = symplectic @ Tv
 
         return cls(f"R{n_transvection}", symplectic, np.zeros(len(symplectic)))
@@ -72,14 +79,21 @@ class Gate(ABC):
     def n_qudits(self) -> int:
         return self._n_qudits
 
-    def phase_vector(self) -> np.ndarray:
-        return self._phase_vector
+    def phase_vector(self, dimension: int = 0) -> np.ndarray:
+        if dimension not in self._phase_vectors:
+            return self._phase_vectors[0]
+        return self._phase_vectors[dimension]
+
+    def set_exceptional_phase_vector(self, dimensions: int | np.ndarray, phase_vector: np.ndarray):
+        if isinstance(dimensions, np.ndarray):
+            dimensions = int(np.lcm.reduce(dimensions))
+        self._phase_vectors[dimensions] = phase_vector
 
     def symplectic(self) -> np.ndarray:
         return self._symplectic
 
     def __repr__(self):
-        return f"Gate(name={self._name}, n_qudits={self._n_qudits}, phase_vector={self._phase_vector})"
+        return f"Gate(name={self._name}, n_qudits={self._n_qudits}, phase_vector={self._phase_vectors})"
 
     # @overload
     # def act(self, pauli: Pauli, qudits: int | list[int] | np.ndarray | tuple[int, ...]) -> Pauli:
@@ -113,24 +127,29 @@ class Gate(ABC):
 
         pauli_dimensions = pauli.dimensions()[affected_qudits]
         relevant_dimensions = np.tile(pauli_dimensions, 2)
+        relevant_lcm = int(np.lcm.reduce(pauli_dimensions))
+
         updated_tableau = np.mod(T_affected @ self._symplectic.T, relevant_dimensions)
         new_tableau = T.copy()
         new_tableau[:, tableau_mask] = updated_tableau
 
-        # FIXME: should we move the phase part to a separate function?
-        linear_terms = T_affected @ self.modified_phase_vector
+        # FIXME: If the gate acts trivially on a qubit, the lcm is not the correct dimension
+        #        This can be the case for a Composite Gate acting trivially on one or more qubits.
+        print(f"USING PHASE VECTOR FOR D={relevant_lcm} => {self.phase_vector(relevant_lcm)}")
+        modified_phase_vector = self.phase_vector(relevant_lcm) - self.V_diag
+        linear_terms = T_affected @ modified_phase_vector
         quadratic_terms = np.sum(T_affected * (T_affected @ self.p_part), axis=1)
 
-        # FIXME: this is a but of a hack
-        dimensional_factor = pauli.lcm() // np.lcm.reduce(pauli_dimensions)
+        # FIXME: this is a bit of a hack
+        dimensional_factor = pauli.lcm() // relevant_lcm
         acquired_phases = (linear_terms + quadratic_terms) * dimensional_factor
 
         new_phases = (pauli.phases() + acquired_phases) % (2 * pauli.lcm())
 
         return pauli.__class__(tableau=new_tableau, dimensions=pauli.dimensions(),
-                               weights=pauli.weights(), phases=new_phases)
+                               weights=pauli.weights().copy(), phases=new_phases)
 
-    def transvection(self, transvection_vector: np.ndarray | list, transvection_weight: int = 1) -> 'Gate':
+    def transvection(self, transvection_vector: np.ndarray | list, transvection_weight: int = 1) -> Gate:
         """
         Returns a new gate that is the transvection of this gate by the given vector.
         The transvection vector should be a 2n-dimensional vector where n is the number of qudits.
@@ -147,7 +166,7 @@ class Gate(ABC):
 
         # FIXME: generate correct phase_vector
         phase_vector = np.zeros(len(self._symplectic))
-        return Gate(self.name(), self.symplectic @ T, phase_vector)
+        return Gate(self.name(), self._symplectic @ T, phase_vector)
 
     def inverse(self) -> 'Gate':
         # TODO: Test for mixed dimensions - not clear that the symplectic form here is correct.
@@ -169,7 +188,7 @@ class Gate(ABC):
         phase_vector = (p1 + p2 + p3)
         return Gate(self.name() + "-inv", C_inv.T, phase_vector)
 
-    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         raise NotImplementedError("Unitary not implemented for generic Gate. Use specific gate subclasses.")
 
 
@@ -184,17 +203,44 @@ class SUM(Gate):
 
         super().__init__("SUM", symplectic, np.zeros(len(symplectic)))
 
-    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
-        D = np.prod(dimensions)
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         if isinstance(qudits, int):
-            qudits = [qudits]
+            qudits = (qudits,)
+        if isinstance(dimensions, int):
+            dimensions = [dimensions]
 
-        a0 = qudits[0]
-        a1 = qudits[1]
-        aa2 = np.array([1 for i in range(D)])
-        aa3 = np.array([CX_func(i, a0, a1, dimensions) for i in range(D)])
-        aa4 = np.array([i for i in range(D)])
-        return sp.csr_matrix((aa2, (aa3, aa4)))
+        # dimensions = list(dimensions)
+        if len(qudits) != 2:
+            raise ValueError("SUM gate requires exactly two qudits.")
+
+        D = int(np.prod(dimensions))
+        a0, a1 = qudits
+
+        d_target = dimensions[a1]
+
+        # build coordinate grid: shape (q, d0, d1, ..., d_{q-1})
+        grid = np.indices(dimensions, dtype=int)
+
+        # perform modular addition on the target axis
+        new_target = (grid[a1] + grid[a0]) % d_target
+
+        # copy and replace the target axis with the new values
+        mapped_grid = grid.copy()
+        mapped_grid[a1] = new_target
+
+        # convert multi-index back to linear indices
+        # IMPORTANT: ravel_multi_index expects a tuple of coordinate arrays
+        mapped_indices = np.ravel_multi_index(tuple(mapped_grid), tuple(dimensions))
+
+        # rows = output indices, cols = input indices
+        rows = mapped_indices.ravel()
+        cols = np.arange(D, dtype=int)
+        data = np.ones(D, dtype=int)
+
+        m = sp.csr_matrix((data, (rows, cols)), shape=(D, D))
+
+        assert m.shape == (D, D)
+        return m
 
 
 class SWAP(Gate):
@@ -208,7 +254,7 @@ class SWAP(Gate):
 
         super().__init__("SWAP", symplectic, np.zeros(len(symplectic)))
 
-    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         # SWAP on two qudits of equal dimension: |i, j> -> |j, i>.
         # Basis ordering |i>⊗|j> with linear index idx(i, j) = i * d + j.
         # normalize inputs
@@ -258,7 +304,7 @@ class Hadamard(Gate):
 
         super().__init__(name, symplectic, np.zeros(len(symplectic)))
 
-    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         if isinstance(qudits, int):
             qudits = [qudits]
 
@@ -274,16 +320,9 @@ class PHASE(Gate):
             [0, 1]   # image of Z:  Z -> Z
         ], dtype=int).T
 
-        super().__init__("S", symplectic, np.zeros(len(symplectic)))
+        super().__init__("S", symplectic, exceptional_phase_vectors={2: np.array([1, 0], dtype=int)})
 
-    # @classmethod
-    # def phase_vector(cls, dimensions: np.ndarray) -> np.ndarray:
-    #     if dimensions == 2:
-    #         return np.array([1, 0], dtype=int)
-
-    #     return np.array([0, 0], dtype=int)
-
-    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: np.ndarray) -> sp.csr_matrix:
+    def unitary(self, qudits: int | tuple[int, ...] | list[int], dimensions: list[int] | np.ndarray) -> sp.csr_matrix:
         if isinstance(qudits, int):
             qudits = [qudits]
         unitary = tensor([S_mat(dimensions[i]) if i in qudits else I_mat(dimensions[i])

--- a/src/sympleq/core/circuits/known_circuits.py
+++ b/src/sympleq/core/circuits/known_circuits.py
@@ -1,10 +1,10 @@
-from .gates import SUM as CX, PHASE as S, Hadamard as H
+from .gates import GATES
 from .circuits import Circuit
 from sympleq.core.finite_field_solvers import solve_modular_linear_additive
 from sympleq.core.paulis import PauliString, PauliSum
 
 
-def add_phase(xz_pauli_sum: PauliSum, qudit_index: int, qudit_index_2: int, phase_key: str) -> Circuit:
+def add_phase(qudit_index: int, qudit_index_2: int, phase_key: str) -> Circuit:
     """
     Uses phase key to alter the phase of a Pauli sum based on the Pauli operator at qudit index 2.
 
@@ -32,211 +32,214 @@ def add_phase(xz_pauli_sum: PauliSum, qudit_index: int, qudit_index_2: int, phas
         ``'SDSD'`` keeps the same phase for all but X and Y Paulis on qudit index 2.
     """
 
-    if xz_pauli_sum.dimensions()[qudit_index] != 2 or xz_pauli_sum.dimensions()[qudit_index] != 2:
-        raise ValueError("Pauli dimensions must be equal to 2")
+    phase_key = phase_key.upper()
 
     if phase_key == 'SSSS':
-        C = Circuit(dimensions=[2 for i in range(xz_pauli_sum.n_qudits())])
-        return C
-    elif phase_key == 'DDSS':
-        C = Circuit(dimensions=[2 for i in range(xz_pauli_sum.n_qudits())],
-                    gates=[CX(qudit_index, qudit_index_2, 2), S(qudit_index_2, 2), H(qudit_index_2, 2),
-                           S(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2)])
-        return C
-    elif phase_key == 'DSDS':
-        C = Circuit(dimensions=[2 for i in range(xz_pauli_sum.n_qudits())],
-                    gates=[CX(qudit_index, qudit_index_2, 2), S(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2),
-                           H(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2), S(qudit_index, 2)])
-        return C
-    elif phase_key == 'DSSD':
-        C = Circuit(dimensions=[2 for i in range(xz_pauli_sum.n_qudits())],
-                    gates=[S(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2), S(qudit_index_2, 2),
-                           H(qudit_index_2, 2), S(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2)])
-        return C
-    elif phase_key == 'SDDS':
-        C = Circuit(dimensions=[2 for i in range(xz_pauli_sum.n_qudits())],
-                    gates=[S(qudit_index_2, 2), H(qudit_index_2, 2), CX(qudit_index_2, qudit_index, 2),
-                           S(qudit_index, 2), CX(qudit_index_2, qudit_index, 2), H(qudit_index_2, 2),
-                           CX(qudit_index, qudit_index_2, 2), S(qudit_index, 2)])
-        return C
-    elif phase_key == 'SDSD':
-        C = Circuit(dimensions=[2 for i in range(xz_pauli_sum.n_qudits())],
-                    gates=[CX(qudit_index_2, qudit_index, 2), S(qudit_index, 2), CX(qudit_index_2, qudit_index, 2),
-                           H(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2), S(qudit_index, 2)])
-        return C
-    elif phase_key == 'SSDD':
-        C = Circuit(dimensions=[2 for i in range(xz_pauli_sum.n_qudits())],
-                    gates=[H(qudit_index_2, 2), CX(qudit_index_2, qudit_index, 2), S(qudit_index, 2),
-                           CX(qudit_index_2, qudit_index, 2), H(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2),
-                           S(qudit_index, 2)])
-        return C
-    elif phase_key == 'DDDD':
-        C = Circuit(dimensions=[2 for i in range(xz_pauli_sum.n_qudits())],
-                    gates=[CX(qudit_index_2, qudit_index, 2), S(qudit_index, 2), CX(qudit_index_2, qudit_index, 2),
-                           H(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2), S(qudit_index, 2),
-                           CX(qudit_index, qudit_index_2, 2), S(qudit_index_2, 2), H(qudit_index_2, 2),
-                           S(qudit_index_2, 2), CX(qudit_index, qudit_index_2, 2)])
-        return C
-    else:
-        raise ValueError(
-            "Invalid phase key. Must be one of 'SSSS', 'DDSS', 'DSDS', 'DSSD', 'SDDS', 'SDSD', 'SSDD', 'DDDD'"
-        )
+        return Circuit.empty()
+
+    CX_data = (GATES.CX, qudit_index, qudit_index_2)
+    S_data = (GATES.S, qudit_index_2)
+    H_data = (GATES.H, qudit_index_2)
+
+    if phase_key == 'DDSS':
+        return Circuit.from_data([CX_data, S_data, H_data, S_data, CX_data])
+
+    if phase_key == 'DSDS':
+        return Circuit.from_data([CX_data, S_data, CX_data, H_data, CX_data, S_data])
+
+    if phase_key == 'DSSD':
+        return Circuit.from_data([S_data, CX_data, S_data, H_data, S_data, CX_data])
+
+    if phase_key == 'SDDS':
+        return Circuit.from_data([S_data, H_data, CX_data, S_data, CX_data, H_data, CX_data, S_data])
+
+    if phase_key == 'SDSD':
+        return Circuit.from_data([CX_data, S_data, CX_data, H_data, CX_data, S_data])
+
+    if phase_key == 'SSDD':
+        return Circuit.from_data([H_data, CX_data, S_data, CX_data, H_data, CX_data, S_data])
+
+    if phase_key == 'DDDD':
+        return Circuit.from_data(
+            [CX_data, S_data, CX_data, H_data, CX_data, S_data, CX_data, S_data, H_data, S_data, CX_data])
+
+    # FIXME: use an enum?
+    raise ValueError(
+        "Invalid phase key. Must be one of 'SSSS', 'DDSS', 'DSDS', 'DSSD', 'SDDS', 'SDSD', 'SSDD', 'DDDD'"
+    )
 
 
-def add_s2(pauli_sum: PauliSum, qudit_index_1: int, qudit_index_2: int) -> Circuit:
+def add_s2(qudit_index_1: int, qudit_index_2: int) -> Circuit:
     """
     xr1zs1 xr2zs2 -> xr1+s2 zs1+s2  *
     """
-    C = Circuit(dimensions=[2 for i in range(pauli_sum.n_qudits())],
-                gates=[CX(qudit_index_1, qudit_index_2, 2), H(qudit_index_2, 2), CX(qudit_index_2, qudit_index_1, 2),
-                       S(qudit_index_2, 2), H(qudit_index_2, 2)])
-    return C
+    return Circuit.from_data([
+        (GATES.CX, qudit_index_1, qudit_index_2),
+        (GATES.H, qudit_index_2),
+        (GATES.CX, qudit_index_2, qudit_index_1),
+        (GATES.S, qudit_index_2),
+        (GATES.H, qudit_index_2),
+    ])
 
 
-def add_r2(pauli_sum: PauliSum, qudit_index_1: int, qudit_index_2: int) -> Circuit:
+def add_r2(qudit_index_1: int, qudit_index_2: int) -> Circuit:
     """
     xr1zs1 xr2zs2 -> xr1+r2 zs1+r2  *
     """
-    C = Circuit(dimensions=[2 for i in range(pauli_sum.n_qudits())],
-                gates=[S(qudit_index_1, 2), CX(qudit_index_2, qudit_index_1, 2), S(qudit_index_1, 2)])
-    return C
+    return Circuit.from_data([
+        (GATES.S, qudit_index_1),
+        (GATES.CX, qudit_index_2, qudit_index_1),
+        (GATES.S, qudit_index_1),
+    ])
 
 
 def add_r2s2(pauli_sum: PauliSum, qudit_index_1: int, qudit_index_2: int) -> Circuit:
     """
     xr1zs1 xr2zs2 -> xr1+r2+s2 zs1+r2+s2  *
     """
-    C = Circuit(dimensions=[2 for i in range(pauli_sum.n_qudits())],
-                gates=[S(qudit_index_2, 2), CX(qudit_index_1, qudit_index_2, 2), H(qudit_index_2, 2),
-                       CX(qudit_index_2, qudit_index_1, 2), S(qudit_index_2, 2), H(qudit_index_2, 2)])
-    return C
+    return Circuit.from_data([
+        (GATES.S, qudit_index_2),
+        (GATES.CX, qudit_index_1, qudit_index_2),
+        (GATES.H, qudit_index_2),
+        (GATES.CX, qudit_index_2, qudit_index_1),
+        (GATES.S, qudit_index_2),
+        (GATES.H, qudit_index_2),
+    ])
 
 
-def _find_first_exp(pauli_sum, pauli_index, target_qubit, exp_type):
-    """Finds the first qubit >= target_qubit with nonzero x_exp or z_exp for pauli_index."""
-    exp = pauli_sum.x_exp if exp_type == 'x' else pauli_sum.z_exp
-    for i in range(target_qubit, pauli_sum.n_qudits()):
-        if exp[pauli_index, i]:
+def _find_first_x_exp(pauli_sum: PauliSum, pauli_index: int, target_qudit: int) -> int | None:
+    """Finds the first qudit >= target_qudit with nonzero x_exp for PauliString at index pauli_index."""
+    for i in range(target_qudit, pauli_sum.n_qudits()):
+        if pauli_sum.x_exp[pauli_index, i]:
             return i
     return None
 
 
-def _apply_h_and_cx(C, pauli_sum, qubit, target_qubit, direction='forward'):
+def _find_first_z_exp(pauli_sum: PauliSum, pauli_index: int, target_qudit: int) -> int | None:
+    """Finds the first qudit >= target_qudit with nonzero z_exp for PauliString at index pauli_index."""
+    for i in range(target_qudit, pauli_sum.n_qudits()):
+        if pauli_sum.z_exp[pauli_index, i]:
+            return i
+    return None
+
+
+def _apply_h_and_cx(
+        C: Circuit, pauli_sum: PauliSum, qudit: int, target_qudit: int,
+        reverse: bool = False) -> tuple[Circuit, PauliSum]:
     """Apply H and CX gates and update pauli_sum."""
-    g = H(qubit, 2)
-    pauli_sum = g.act(pauli_sum)
-    C.add_gate(g)
-    if direction == 'forward':
-        g = CX(target_qubit, qubit, 2)
+    C.add_gate(GATES.H, qudit)
+    if reverse:
+        C.add_gate(GATES.CX, qudit, target_qudit)
     else:
-        g = CX(qubit, target_qubit, 2)
-    C.add_gate(g)
-    pauli_sum = g.act(pauli_sum)
+        C.add_gate(GATES.CX, target_qudit, qudit)
+
+    pauli_sum = Circuit.act(pauli_sum)
     return C, pauli_sum
 
 
-def _handle_xz_case(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit):
-    px = None
-    if pauli_sum.x_exp[pauli_index_x, target_qubit] == 1 and pauli_sum.z_exp[pauli_index_z, target_qubit] == 1:
-        px = pauli_index_x
-    elif pauli_sum.z_exp[pauli_index_x, target_qubit] == 1 and pauli_sum.x_exp[pauli_index_z, target_qubit] == 1:
-        px = pauli_index_z
-    return px
+def _handle_xz_case(pauli_sum: PauliSum, pauli_index_x: int, pauli_index_z: int, target_qudit: int) -> int | None:
+    if pauli_sum.x_exp[pauli_index_x, target_qudit] == 1 and pauli_sum.z_exp[pauli_index_z, target_qudit] == 1:
+        return pauli_index_x
+    if pauli_sum.z_exp[pauli_index_x, target_qudit] == 1 and pauli_sum.x_exp[pauli_index_z, target_qudit] == 1:
+        return pauli_index_z
+
+    return None
 
 
-def _handle_x_id_or_x_x(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit):
+def _handle_x_id_or_x_x(C: Circuit, pauli_sum: PauliSum,
+                        pauli_index_x: int, pauli_index_z: int, target_qudit: int) -> tuple[Circuit, PauliSum, int]:
+    z_qubit = _find_first_z_exp(pauli_sum, pauli_index_z, target_qudit)
+    x_qubit = _find_first_x_exp(pauli_sum, pauli_index_z, target_qudit)
+    if z_qubit is None and x_qubit is not None:
+        C, pauli_sum = _apply_h_and_cx(C, pauli_sum, x_qubit, target_qudit)
+        z_qubit = _find_first_z_exp(pauli_sum, pauli_index_z, target_qudit)
+
+    if z_qubit is None:
+        raise Exception("Both x and z exp are zero.")
+
+    C.add_gate(GATES.CX, target_qudit, z_qubit)
+    pauli_sum = GATES.CX.act(pauli_sum, target_qudit, z_qubit)
+    return C, pauli_sum, pauli_index_x
+
+
+def _handle_z_id_or_z_z(C, pauli_sum, pauli_index_z, target_qudit):
     px = None
-    z_qubit = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'z')
-    x_qubit = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'x')
-    if z_qubit is not None:
-        g = CX(target_qubit, z_qubit, 2)
-    elif x_qubit is not None:
-        C, pauli_sum = _apply_h_and_cx(C, pauli_sum, x_qubit, target_qubit, direction='forward')
-        z_qubit = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'z')
-        g = CX(target_qubit, z_qubit, 2)
+    x_qubit = _find_first_x_exp(pauli_sum, pauli_index_z, target_qudit)
+    z_qubit = _find_first_z_exp(pauli_sum, pauli_index_z, target_qudit)
+    if x_qubit is None and z_qubit is not None:
+        C, pauli_sum = _apply_h_and_cx(C, pauli_sum, z_qubit, target_qudit, reverse=True)
+        x_qubit = _find_first_x_exp(pauli_sum, pauli_index_z, target_qudit)
+
+    if x_qubit is None:
+        raise Exception("Both x and z exp are zero.")
+
+    C.add_gate(GATES.CX, x_qubit, target_qudit)
+    pauli_sum = GATES.CX.act(pauli_sum, x_qubit, target_qudit)
+    px = pauli_index_z
+    return C, pauli_sum, px
+
+
+def _handle_id_z(C, pauli_sum, pauli_index_x, target_qudit):
+    px = None
+    x_qubit = _find_first_x_exp(pauli_sum, pauli_index_x, target_qudit)
+    z_qubit = _find_first_z_exp(pauli_sum, pauli_index_x, target_qudit)
+    if x_qubit is not None:
+        g = CX(x_qubit, target_qudit, 2)
+    elif z_qubit is not None:
+        C, pauli_sum = _apply_h_and_cx(C, pauli_sum, z_qubit, target_qudit, reverse=True)
+        x_qubit = _find_first_x_exp(pauli_sum, pauli_index_x, target_qudit)
+        g = CX(x_qubit, target_qudit, 2)
     C.add_gate(g)
     pauli_sum = g.act(pauli_sum)
     px = pauli_index_x
     return C, pauli_sum, px
 
 
-def _handle_z_id_or_z_z(C, pauli_sum, pauli_index_z, target_qubit):
+def _handle_id_x(C, pauli_sum, pauli_index_x, pauli_index_z, target_qudit):
     px = None
-    x_qubit = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'x')
-    z_qubit = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'z')
-    if x_qubit is not None:
-        g = CX(x_qubit, target_qubit, 2)
-    elif z_qubit is not None:
-        C, pauli_sum = _apply_h_and_cx(C, pauli_sum, z_qubit, target_qubit, direction='backward')
-        x_qubit = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'x')
-        g = CX(x_qubit, target_qubit, 2)
-    C.add_gate(g)
-    pauli_sum = g.act(pauli_sum)
-    px = pauli_index_z
-    return C, pauli_sum, px
-
-
-def _handle_id_z(C, pauli_sum, pauli_index_x, target_qubit):
-    px = None
-    x_qubit = _find_first_exp(pauli_sum, pauli_index_x, target_qubit, 'x')
-    z_qubit = _find_first_exp(pauli_sum, pauli_index_x, target_qubit, 'z')
-    if x_qubit is not None:
-        g = CX(x_qubit, target_qubit, 2)
-    elif z_qubit is not None:
-        C, pauli_sum = _apply_h_and_cx(C, pauli_sum, z_qubit, target_qubit, direction='backward')
-        x_qubit = _find_first_exp(pauli_sum, pauli_index_x, target_qubit, 'x')
-        g = CX(x_qubit, target_qubit, 2)
-    C.add_gate(g)
-    pauli_sum = g.act(pauli_sum)
-    px = pauli_index_x
-    return C, pauli_sum, px
-
-
-def _handle_id_x(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit):
-    px = None
-    z_qubit = _find_first_exp(pauli_sum, pauli_index_x, target_qubit, 'z')
-    x_qubit = _find_first_exp(pauli_sum, pauli_index_x, target_qubit, 'x')
+    z_qubit = _find_first_z_exp(pauli_sum, pauli_index_x, target_qudit)
+    x_qubit = _find_first_x_exp(pauli_sum, pauli_index_x, target_qudit)
     if z_qubit is not None:
-        g = CX(target_qubit, z_qubit, 2)
+        g = CX(target_qudit, z_qubit, 2)
     elif x_qubit is not None:
-        C, pauli_sum = _apply_h_and_cx(C, pauli_sum, x_qubit, target_qubit, direction='forward')
-        z_qubit = _find_first_exp(pauli_sum, pauli_index_x, target_qubit, 'z')
-        g = CX(target_qubit, z_qubit, 2)
+        C, pauli_sum = _apply_h_and_cx(C, pauli_sum, x_qubit, target_qudit)
+        z_qubit = _find_first_z_exp(pauli_sum, pauli_index_x, target_qudit)
+        g = CX(target_qudit, z_qubit, 2)
     C.add_gate(g)
     pauli_sum = g.act(pauli_sum)
     px = pauli_index_z
     return C, pauli_sum, px
 
 
-def _handle_id_id(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit):
+def _handle_id_id(C, pauli_sum, pauli_index_x, pauli_index_z, target_qudit):
     px = None
-    x_qubit_x = _find_first_exp(pauli_sum, pauli_index_x, target_qubit, 'x')
-    z_qubit_x = _find_first_exp(pauli_sum, pauli_index_x, target_qubit, 'z')
-    x_qubit_z = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'x')
-    z_qubit_z = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'z')
+    x_qubit_x = _find_first_x_exp(pauli_sum, pauli_index_x, target_qudit)
+    z_qubit_x = _find_first_z_exp(pauli_sum, pauli_index_x, target_qudit)
+    x_qubit_z = _find_first_x_exp(pauli_sum, pauli_index_z, target_qudit)
+    z_qubit_z = _find_first_z_exp(pauli_sum, pauli_index_z, target_qudit)
     if x_qubit_x is not None:
-        g = CX(x_qubit_x, target_qubit, 2)
+        g = GATES.CX(x_qubit_x, target_qudit, 2)
         pauli_sum = g.act(pauli_sum)
         C.add_gate(g)
         if z_qubit_z is not None:
-            g = CX(target_qubit, z_qubit_z, 2)
+            g = GATES.CX(target_qudit, z_qubit_z, 2)
         elif x_qubit_z is not None:
-            C, pauli_sum = _apply_h_and_cx(C, pauli_sum, x_qubit_z, target_qubit, direction='forward')
-            z_qubit_z = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'z')
-            g = CX(target_qubit, z_qubit_z, 2)
+            C, pauli_sum = _apply_h_and_cx(C, pauli_sum, x_qubit_z, target_qudit)
+            z_qubit_z = _find_first_z_exp(pauli_sum, pauli_index_z, target_qudit)
+            g = GATES.CX(target_qudit, z_qubit_z, 2)
         C.add_gate(g)
         pauli_sum = g.act(pauli_sum)
         px = pauli_index_x
     elif z_qubit_x is not None:
-        g = CX(target_qubit, z_qubit_x, 2)
+        g = GATES.CX(target_qudit, z_qubit_x, 2)
         pauli_sum = g.act(pauli_sum)
         C.add_gate(g)
         if x_qubit_z is not None:
-            g = CX(x_qubit_z, target_qubit, 2)
+            g = GATES.CX(x_qubit_z, target_qudit, 2)
         elif z_qubit_z is not None:
-            C, pauli_sum = _apply_h_and_cx(C, pauli_sum, z_qubit_z, target_qubit, direction='backward')
-            x_qubit_z = _find_first_exp(pauli_sum, pauli_index_z, target_qubit, 'x')
-            g = CX(x_qubit_z, target_qubit, 2)
+            C, pauli_sum = _apply_h_and_cx(C, pauli_sum, z_qubit_z, target_qudit, reverse=True)
+            x_qubit_z = _find_first_x_exp(pauli_sum, pauli_index_z, target_qudit)
+            g = GATES.CX(x_qubit_z, target_qudit, 2)
         C.add_gate(g)
         pauli_sum = g.act(pauli_sum)
         px = pauli_index_z
@@ -244,39 +247,39 @@ def _handle_id_id(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit):
 
 
 def ensure_zx_components(pauli_sum: PauliSum, pauli_index_x: int,
-                         pauli_index_z: int, target_qubit: int) -> tuple[Circuit, PauliSum]:
+                         pauli_index_z: int, target_qudit: int) -> tuple[Circuit, PauliSum]:
     """
     Assumes anti-commutation between pauli_index_x and pauli_index_z.
     brings pauli_sum to the form:
 
-    target_qubit
+    target_qudit
     pauli_index_x |  xr1zs1
     pauli_index_z |  xr2zs2
     where r1 and s2 are always non-zero
 
     """
-    if not pauli_sum[pauli_index_x, target_qubit:].commute(pauli_sum[pauli_index_z, target_qubit:]):
+    if not pauli_sum[pauli_index_x, target_qudit:].commute(pauli_sum[pauli_index_z, target_qudit:]):
         raise ValueError(("ensure_zx_components requires anti-commutation"
-                          " between pauli_index_x and pauli_index_z beyond target_qubit"))
+                          " between pauli_index_x and pauli_index_z beyond target_qudit"))
 
-    C = Circuit(dimensions=pauli_sum.dimensions())
-    px = _handle_xz_case(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit)
+    C = Circuit.empty()
+    px = _handle_xz_case(pauli_sum, pauli_index_x, pauli_index_z, target_qudit)
     if px is not None:
         pass
-    elif pauli_sum.x_exp[pauli_index_x, target_qubit] == 1 and pauli_sum.z_exp[pauli_index_z, target_qubit] == 0:
-        C, pauli_sum, px = _handle_x_id_or_x_x(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit)
-    elif pauli_sum.z_exp[pauli_index_x, target_qubit] == 1 and pauli_sum.x_exp[pauli_index_z, target_qubit] == 0:
-        C, pauli_sum, px = _handle_z_id_or_z_z(C, pauli_sum, pauli_index_z, target_qubit)
-    elif pauli_sum.x_exp[pauli_index_x, target_qubit] == 0 and pauli_sum.z_exp[pauli_index_z, target_qubit] == 1:
-        C, pauli_sum, px = _handle_id_z(C, pauli_sum, pauli_index_x, target_qubit)
-    elif pauli_sum.x_exp[pauli_index_x, target_qubit] == 0 and pauli_sum.x_exp[pauli_index_z, target_qubit] == 1:
-        C, pauli_sum, px = _handle_id_x(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit)
+    elif pauli_sum.x_exp[pauli_index_x, target_qudit] == 1 and pauli_sum.z_exp[pauli_index_z, target_qudit] == 0:
+        C, pauli_sum, px = _handle_x_id_or_x_x(C, pauli_sum, pauli_index_x, pauli_index_z, target_qudit)
+    elif pauli_sum.z_exp[pauli_index_x, target_qudit] == 1 and pauli_sum.x_exp[pauli_index_z, target_qudit] == 0:
+        C, pauli_sum, px = _handle_z_id_or_z_z(C, pauli_sum, pauli_index_z, target_qudit)
+    elif pauli_sum.x_exp[pauli_index_x, target_qudit] == 0 and pauli_sum.z_exp[pauli_index_z, target_qudit] == 1:
+        C, pauli_sum, px = _handle_id_z(C, pauli_sum, pauli_index_x, target_qudit)
+    elif pauli_sum.x_exp[pauli_index_x, target_qudit] == 0 and pauli_sum.x_exp[pauli_index_z, target_qudit] == 1:
+        C, pauli_sum, px = _handle_id_x(C, pauli_sum, pauli_index_x, pauli_index_z, target_qudit)
     else:
-        C, pauli_sum, px = _handle_id_id(C, pauli_sum, pauli_index_x, pauli_index_z, target_qubit)
+        C, pauli_sum, px = _handle_id_id(C, pauli_sum, pauli_index_x, pauli_index_z, target_qudit)
 
     if px == pauli_index_z:
-        C.add_gate(H(target_qubit, 2))
-        pauli_sum = H(target_qubit, 2).act(pauli_sum)
+        C.add_gate(GATES.H, target_qudit)
+        pauli_sum = GATES.H.act(pauli_sum, target_qudit)
 
     return C, pauli_sum
 
@@ -303,15 +306,15 @@ def to_ix(pauli_string: PauliString, target_index: int, ignore: int | list[int] 
     for q in range(n_q):
         if q != target_index and q not in ignore:
             if pauli_string[q].x_exp == 0 and pauli_string[q].z_exp != 0:
-                circuit.add_gate(H(q, pauli_string.dimensions()[q]))
+                circuit.add_gate(GATES.H, q)
                 pauli_string = circuit.act(p_string_in)
             if pauli_string[q].x_exp != 0:
                 if pauli_string[q].z_exp != 0:
                     # use the x to cancel the z of q with S gates
                     n_s = solve_modular_linear_additive(pauli_string[q].x_exp, pauli_string[q].z_exp,
                                                         pauli_string.dimensions()[q])
-                    for i in range(n_s):
-                        circuit.add_gate(S(q, pauli_string.dimensions()[q]))
+                    for _ in range(n_s):
+                        circuit.add_gate(GATES.S, q)
                     pauli_string = circuit.act(p_string_in)
 
                 # use cnot to cancel the x of q with the x of target. n_cnot = n where x_q + x+_target) % d = 0
@@ -320,7 +323,7 @@ def to_ix(pauli_string: PauliString, target_index: int, ignore: int | list[int] 
                 if n_cnot is None:
                     raise Exception("Weird")
                 for i in range(n_cnot):
-                    circuit.add_gate(CX(target_index, q, pauli_string.dimensions()[target_index]))
+                    circuit.add_gate(GATES.CX, target_index, q)
                 pauli_string = circuit.act(p_string_in)
 
     else:
@@ -353,28 +356,29 @@ def _single_qudit_x(pauli_string, target_index, circuit):
     elif x_exp != 0 and z_exp != 0:
         n_s_gates = solve_modular_linear_additive(z_exp, x_exp, dim_target)
         for _ in range(n_s_gates):
-            circuit.add_gate(S(target_index, dim_target))
+            circuit.add_gate(GATES.S, target_index)
         return circuit
     elif x_exp == 0 and z_exp != 0:
-        circuit.add_gate(H(target_index, dim_target))
+        circuit.add_gate(GATES.H, target_index)
         return circuit
+
     return None  # Not handled here
 
 
 def _multi_qudit_x(pauli_string, target_index, ignore, circuit):
     n_q = pauli_string.n_qudits()
-    dim_target = pauli_string.dimensions()[target_index]
     for q in range(n_q - 1, -1, -1):
         if q != target_index and q not in ignore:
             x_exp = pauli_string[q].x_exp
             z_exp = pauli_string[q].z_exp
             if x_exp != 0:
-                circuit.add_gate(CX(q, target_index, dim_target))
+                circuit.add_gate(GATES.CX, q, target_index)
                 return circuit
             if x_exp == 0 and z_exp != 0:
-                circuit.add_gate(CX(target_index, q, dim_target))
-                circuit.add_gate(H(target_index, dim_target))
+                circuit.add_gate(GATES.CX, target_index, q)
+                circuit.add_gate(GATES.H, target_index)
                 return circuit
+
     raise Exception(f"No circuit found to convert {pauli_string} pauli to X")
 
 
@@ -382,7 +386,7 @@ def to_x(pauli_string: PauliString, target_index: int, ignore: int | list[int] |
     """Finds a circuit to turn a PauliString to ****X*** where the X is at target_index"""
 
     ignore, target_index = _validate_inputs(pauli_string, target_index, ignore)
-    circuit = Circuit(dimensions=pauli_string.dimensions())
+    circuit = Circuit.empty()
     result = _single_qudit_x(pauli_string, target_index, circuit)
     if result is not None:
         return result

--- a/src/sympleq/core/circuits/known_circuits.py
+++ b/src/sympleq/core/circuits/known_circuits.py
@@ -133,7 +133,7 @@ def _apply_h_and_cx(
     else:
         C.add_gate(GATES.CX, target_qudit, qudit)
 
-    pauli_sum = Circuit.act(pauli_sum)
+    pauli_sum = C.act(pauli_sum)
     return C, pauli_sum
 
 
@@ -158,7 +158,7 @@ def _handle_x_id_or_x_x(C: Circuit, pauli_sum: PauliSum,
         raise Exception("Both x and z exp are zero.")
 
     C.add_gate(GATES.CX, target_qudit, z_qubit)
-    pauli_sum = GATES.CX.act(pauli_sum, target_qudit, z_qubit)
+    pauli_sum = GATES.CX.act(pauli_sum, (target_qudit, z_qubit))
     return C, pauli_sum, pauli_index_x
 
 
@@ -174,7 +174,7 @@ def _handle_z_id_or_z_z(C, pauli_sum, pauli_index_z, target_qudit):
         raise Exception("Both x and z exp are zero.")
 
     C.add_gate(GATES.CX, x_qubit, target_qudit)
-    pauli_sum = GATES.CX.act(pauli_sum, x_qubit, target_qudit)
+    pauli_sum = GATES.CX.act(pauli_sum, (x_qubit, target_qudit))
     px = pauli_index_z
     return C, pauli_sum, px
 
@@ -183,14 +183,15 @@ def _handle_id_z(C, pauli_sum, pauli_index_x, target_qudit):
     px = None
     x_qubit = _find_first_x_exp(pauli_sum, pauli_index_x, target_qudit)
     z_qubit = _find_first_z_exp(pauli_sum, pauli_index_x, target_qudit)
-    if x_qubit is not None:
-        g = CX(x_qubit, target_qudit, 2)
-    elif z_qubit is not None:
+    if x_qubit is None and z_qubit is not None:
         C, pauli_sum = _apply_h_and_cx(C, pauli_sum, z_qubit, target_qudit, reverse=True)
         x_qubit = _find_first_x_exp(pauli_sum, pauli_index_x, target_qudit)
-        g = CX(x_qubit, target_qudit, 2)
-    C.add_gate(g)
-    pauli_sum = g.act(pauli_sum)
+
+    if x_qubit is None:
+        raise Exception("Both x and z exp are zero.")
+
+    C.add_gate(GATES.CX, x_qubit, target_qudit)
+    pauli_sum = GATES.CX.act(pauli_sum, (x_qubit, target_qudit))
     px = pauli_index_x
     return C, pauli_sum, px
 
@@ -199,14 +200,15 @@ def _handle_id_x(C, pauli_sum, pauli_index_x, pauli_index_z, target_qudit):
     px = None
     z_qubit = _find_first_z_exp(pauli_sum, pauli_index_x, target_qudit)
     x_qubit = _find_first_x_exp(pauli_sum, pauli_index_x, target_qudit)
-    if z_qubit is not None:
-        g = CX(target_qudit, z_qubit, 2)
-    elif x_qubit is not None:
+    if z_qubit is None and x_qubit is not None:
         C, pauli_sum = _apply_h_and_cx(C, pauli_sum, x_qubit, target_qudit)
         z_qubit = _find_first_z_exp(pauli_sum, pauli_index_x, target_qudit)
-        g = CX(target_qudit, z_qubit, 2)
-    C.add_gate(g)
-    pauli_sum = g.act(pauli_sum)
+
+    if z_qubit is None:
+        raise Exception("Both x and z exp are zero.")
+
+    C.add_gate(GATES.CX, target_qudit, z_qubit)
+    pauli_sum = GATES.CX.act(pauli_sum, (target_qudit, z_qubit))
     px = pauli_index_z
     return C, pauli_sum, px
 
@@ -218,30 +220,30 @@ def _handle_id_id(C, pauli_sum, pauli_index_x, pauli_index_z, target_qudit):
     x_qubit_z = _find_first_x_exp(pauli_sum, pauli_index_z, target_qudit)
     z_qubit_z = _find_first_z_exp(pauli_sum, pauli_index_z, target_qudit)
     if x_qubit_x is not None:
-        g = GATES.CX(x_qubit_x, target_qudit, 2)
-        pauli_sum = g.act(pauli_sum)
-        C.add_gate(g)
-        if z_qubit_z is not None:
-            g = GATES.CX(target_qudit, z_qubit_z, 2)
-        elif x_qubit_z is not None:
+        pauli_sum = GATES.CX.act(pauli_sum, (x_qubit_x, target_qudit))
+        C.add_gate(GATES.CX, x_qubit_x, target_qudit)
+        if z_qubit_z is None and x_qubit_z is not None:
             C, pauli_sum = _apply_h_and_cx(C, pauli_sum, x_qubit_z, target_qudit)
             z_qubit_z = _find_first_z_exp(pauli_sum, pauli_index_z, target_qudit)
-            g = GATES.CX(target_qudit, z_qubit_z, 2)
-        C.add_gate(g)
-        pauli_sum = g.act(pauli_sum)
+
+        if z_qubit_z is None:
+            raise Exception("Both x and z exp are zero.")
+
+        C.add_gate(GATES.CX, target_qudit, z_qubit_z)
+        pauli_sum = GATES.CX.act(pauli_sum, (target_qudit, z_qubit_z))
         px = pauli_index_x
     elif z_qubit_x is not None:
-        g = GATES.CX(target_qudit, z_qubit_x, 2)
-        pauli_sum = g.act(pauli_sum)
-        C.add_gate(g)
-        if x_qubit_z is not None:
-            g = GATES.CX(x_qubit_z, target_qudit, 2)
-        elif z_qubit_z is not None:
+        pauli_sum = GATES.CX.act(pauli_sum, (target_qudit, z_qubit_x))
+        C.add_gate(GATES.CX, target_qudit, z_qubit_x)
+        if x_qubit_z is None and z_qubit_z is not None:
             C, pauli_sum = _apply_h_and_cx(C, pauli_sum, z_qubit_z, target_qudit, reverse=True)
             x_qubit_z = _find_first_x_exp(pauli_sum, pauli_index_z, target_qudit)
-            g = GATES.CX(x_qubit_z, target_qudit, 2)
-        C.add_gate(g)
-        pauli_sum = g.act(pauli_sum)
+
+        if x_qubit_z is None:
+            raise Exception("Both x and z exp are zero.")
+
+        C.add_gate(GATES.CX, x_qubit_z, target_qudit)
+        pauli_sum = GATES.CX.act(pauli_sum, (x_qubit_z, target_qudit))
         px = pauli_index_z
     return C, pauli_sum, px
 
@@ -347,7 +349,7 @@ def _validate_inputs(pauli_string, target_index, ignore):
     return ignore, target_index
 
 
-def _single_qudit_x(pauli_string, target_index, circuit):
+def _single_qudit_x(pauli_string: PauliString, target_index: int, circuit: Circuit) -> Circuit | None:
     dim_target = pauli_string.dimensions()[target_index]
     x_exp = pauli_string[target_index].x_exp
     z_exp = pauli_string[target_index].z_exp

--- a/src/sympleq/core/circuits/target.py
+++ b/src/sympleq/core/circuits/target.py
@@ -23,10 +23,12 @@ def find_map_to_target_pauli_sum(input_pauli: PauliSum, target_pauli: PauliSum) 
         images (list[np.ndarray]): The images of the gate.
         h (np.ndarray): The phase vector of the gate.
         """
-    if np.array_equal(input_pauli.dimensions(), target_pauli.dimensions()):
-        raise ValueError("PauliSum and gate must have the same dimensions.")
+    if not np.array_equal(input_pauli.dimensions(), target_pauli.dimensions()):
+        raise ValueError(
+            f"Input and output PauliSums must have the same dimensions\
+            (got {input_pauli.dimensions()} and {target_pauli.dimensions()}).")
 
-    if np.all(input_pauli.symplectic_product_matrix() != target_pauli.symplectic_product_matrix()):
+    if not np.array_equal(input_pauli.symplectic_product_matrix(), target_pauli.symplectic_product_matrix()):
         raise ValueError("Input and target PauliSum must be symplectically equivalent.")
 
     input_symplectic = input_pauli.tableau()  # [:, qudit_indices]

--- a/src/sympleq/core/circuits/target.py
+++ b/src/sympleq/core/circuits/target.py
@@ -6,37 +6,25 @@ from itertools import product
 from sympleq.core.circuits.find_symplectic import map_pauli_sum_to_target_tableau
 
 
-def find_map_to_target_pauli_sum(input_pauli: PauliSum, target_pauli: PauliSum) -> tuple[np.ndarray, np.ndarray,
-                                                                                         list[int], int]:
+# FIXME: improve function name and docstring
+def find_map_to_target_pauli_sum(input_pauli: PauliSum, target_pauli: PauliSum) -> tuple[np.ndarray, np.ndarray]:
     """
     TODO: For efficiency improvement act only on target qudits
 
     Find a gate that maps Pauli P to target Pauli.
 
     Args:
-        P (Pauli): The Pauli to be mapped.
-        target (Pauli): The target Pauli.
-        dimension (int): The dimension of the qudit.
+        input_pauli: PauliSum
+            The Pauli to be mapped.
+        target_pauli: : PauliSum
+            The target Pauli.
 
     Returns:
         images (list[np.ndarray]): The images of the gate.
         h (np.ndarray): The phase vector of the gate.
-        qudit_indices (list[int]): The indices of the qudits acted upon by the gate.
-        gate_dimension (int): The dimension of the gate.
         """
-    if np.all(input_pauli.dimensions() != target_pauli.dimensions()):
-        raise ValueError("PauliSum and gate must have the same dimension.")
-
-    n_qudits = input_pauli.n_qudits()
-    if n_qudits != target_pauli.n_qudits():
-        raise ValueError("PauliSum and target must have the same number of qudits.")
-
-    # get list of qudits where input and target differ
-    qudit_indices = list(range(n_qudits))
-    gate_dimension = input_pauli.dimensions()[qudit_indices[0]]
-
-    if not np.all(input_pauli.dimensions()[qudit_indices] == gate_dimension):
-        raise ValueError("PauliSum must have the same dimension for all qudits acted upon by the gate.")
+    if np.array_equal(input_pauli.dimensions(), target_pauli.dimensions()):
+        raise ValueError("PauliSum and gate must have the same dimensions.")
 
     if np.all(input_pauli.symplectic_product_matrix() != target_pauli.symplectic_product_matrix()):
         raise ValueError("Input and target PauliSum must be symplectically equivalent.")
@@ -45,16 +33,10 @@ def find_map_to_target_pauli_sum(input_pauli: PauliSum, target_pauli: PauliSum) 
     target_symplectic = target_pauli.tableau()  # [:, qudit_indices]
 
     F = map_pauli_sum_to_target_tableau(input_symplectic, target_symplectic)
+    # FIXME: should take input_pauli phases into consideration
+    h = get_phase_vector(F, input_pauli.lcm())
 
-    # print('IN FUNCTION')
-    # # print(input_symplectic)
-    # # print()
-    # print(target_symplectic - input_symplectic @ F % 2)
-    # print('----------')
-
-    h = get_phase_vector(F, gate_dimension)
-
-    return F, h, qudit_indices, gate_dimension
+    return F, h
 
 
 def find_allowed_target(pauli_sum, target_pauli_list):
@@ -116,7 +98,7 @@ def find_allowed_target(pauli_sum, target_pauli_list):
     return possible_targets
 
 
-def get_phase_vector(gate_symplectic: np.ndarray, dimension: int) -> np.ndarray:
+def get_phase_vector(gate_symplectic: np.ndarray, lcm: int) -> np.ndarray:
     """
     Calculate the phase vector for a gate given its symplectic matrix.
 
@@ -134,8 +116,7 @@ def get_phase_vector(gate_symplectic: np.ndarray, dimension: int) -> np.ndarray:
 
     U = np.zeros((2 * n_qudits, 2 * n_qudits), dtype=int)
     U[n_qudits:, :n_qudits] = np.eye(n_qudits, dtype=int)
-    lhs = (dimension - 1) * np.diag(gate_symplectic.T @ U @ gate_symplectic) % 2
-    return lhs
+    return (lcm - 1) * np.diag(gate_symplectic.T @ U @ gate_symplectic) % 2
 
 
 def str_to_int(string):

--- a/src/sympleq/core/circuits/utils.py
+++ b/src/sympleq/core/circuits/utils.py
@@ -51,13 +51,12 @@ def symplectic_product_matrix(pauli_sum: np.ndarray) -> np.ndarray:
     return spm
 
 
-def symplectic_form(n: int, p: int = 2) -> np.ndarray:
+def symplectic_form(n: int) -> np.ndarray:
     """
     Construct the symplectic matrix Omega for a given dimension n over GF(p).
 
     Args:
         n: Half the length of the vectors (2n is the full length)
-        p: Modulus (default 2)
 
     Returns:
         Omega matrix as a 2n x 2n numpy array
@@ -65,15 +64,13 @@ def symplectic_form(n: int, p: int = 2) -> np.ndarray:
     Id = np.eye(n, dtype=int)
     Z = np.zeros((n, n), dtype=int)
 
-    if p == 2:
-        return np.block([[Z, Id], [Id, Z]])
-    else:
-        return np.block([[Z, Id], [-Id, Z]])
+    return np.block([[Z, Id], [-Id, Z]])
 
 
-def transvection_matrix(h: np.ndarray, p=2, multiplier=1):
+def transvection_matrix(h: np.ndarray, multiplier: int = 1) -> np.ndarray:
     """
     Compute the transvection matrix corresponding to the vector h.
+    NOTE: we do not take any modulo operation here.
 
     Args:
         h: Binary vector of length 2n
@@ -83,12 +80,13 @@ def transvection_matrix(h: np.ndarray, p=2, multiplier=1):
         The transvection matrix as a 2n x 2n matrix over integers modulo p
     """
     n = len(h) // 2
-    Omega = symplectic_form(n, p)
+    Omega = symplectic_form(n)
 
-    F_h = (np.eye(2 * n, dtype=int) + multiplier * (Omega @ np.outer(h.T, h))) % p
+    F_h = (np.eye(2 * n, dtype=int) + multiplier * (Omega @ np.outer(h.T, h)))
     return F_h
 
 
+# FIXME: pick a different name, there are too many things named transvection
 def transvection(h, x, p=2):
     return (x + symplectic_product_arrays(x, h.T, p) * h) % p
 

--- a/src/sympleq/core/circuits/utils.py
+++ b/src/sympleq/core/circuits/utils.py
@@ -91,7 +91,8 @@ def transvection(h, x, p=2):
     return (x + symplectic_product_arrays(x, h.T, p) * h) % p
 
 
-def embed_symplectic(symplectic_local, phase_vector_local, qudit_indices, n_qudits):
+def embed_symplectic(symplectic_local: np.ndarray, phase_vector_local: np.ndarray,
+                     qudit_indices: tuple[int, ...], n_qudits: int) -> tuple[np.ndarray, np.ndarray]:
     """
     Embed a local Clifford (F_local, h_local) into a larger 2n-dimensional space,
     correctly handling arbitrary qudit index ordering.
@@ -106,12 +107,13 @@ def embed_symplectic(symplectic_local, phase_vector_local, qudit_indices, n_qudi
     F_full = np.eye(2 * n_qudits, dtype=int)
     h_full = np.zeros(2 * n_qudits, dtype=int)
 
-    qudit_indices = np.array(qudit_indices, dtype=int)
+    qudits_array = np.asarray(qudit_indices, dtype=int)
 
     # Build row/column index mapping for the full space
     # First X rows/columns
-    row_indices = np.concatenate([qudit_indices, n_qudits + qudit_indices])
-    col_indices = np.concatenate([qudit_indices, n_qudits + qudit_indices])
+    # FIXME: why do we do this twice?
+    row_indices = np.concatenate([qudit_indices, n_qudits + qudits_array])
+    col_indices = np.concatenate([qudit_indices, n_qudits + qudits_array])
 
     # Place the full local symplectic block into the full system
     F_full[np.ix_(row_indices, col_indices)] = symplectic_local

--- a/src/sympleq/core/circuits/utils.py
+++ b/src/sympleq/core/circuits/utils.py
@@ -73,7 +73,7 @@ def transvection_matrix(h: np.ndarray, multiplier: int = 1) -> np.ndarray:
     NOTE: we do not take any modulo operation here.
 
     Args:
-        h: Binary vector of length 2n
+        h: Vector of length 2n
         p: Modulus (default 2)
 
     Returns:
@@ -91,8 +91,7 @@ def transvection(h, x, p=2):
     return (x + symplectic_product_arrays(x, h.T, p) * h) % p
 
 
-def embed_symplectic(symplectic_local: np.ndarray, phase_vector_local: np.ndarray,
-                     qudit_indices: tuple[int, ...], n_qudits: int) -> tuple[np.ndarray, np.ndarray]:
+def embed_symplectic(symplectic_local: np.ndarray, qudit_indices: tuple[int, ...], n_qudits: int) -> np.ndarray:
     """
     Embed a local Clifford (F_local, h_local) into a larger 2n-dimensional space,
     correctly handling arbitrary qudit index ordering.
@@ -100,12 +99,9 @@ def embed_symplectic(symplectic_local: np.ndarray, phase_vector_local: np.ndarra
     m = len(qudit_indices)
     if symplectic_local.shape != (2 * m, 2 * m):
         raise ValueError("symplectic_local must be 2m x 2m")
-    if len(phase_vector_local) != 2 * m:
-        raise ValueError("phase_vector_local must have length 2m")
 
     # Full 2n x 2n identity
     F_full = np.eye(2 * n_qudits, dtype=int)
-    h_full = np.zeros(2 * n_qudits, dtype=int)
 
     qudits_array = np.asarray(qudit_indices, dtype=int)
 
@@ -117,11 +113,27 @@ def embed_symplectic(symplectic_local: np.ndarray, phase_vector_local: np.ndarra
 
     # Place the full local symplectic block into the full system
     F_full[np.ix_(row_indices, col_indices)] = symplectic_local
+    return F_full
+
+
+def embed_phase_vector(phase_vector_local: np.ndarray,
+                       qudit_indices: tuple[int, ...], n_qudits: int) -> np.ndarray:
+    """
+    Embed a local Clifford (F_local, h_local) into a larger 2n-dimensional space,
+    correctly handling arbitrary qudit index ordering.
+    """
+    m = len(qudit_indices)
+    if len(phase_vector_local) != 2 * m:
+        raise ValueError("phase_vector_local must have length 2m")
+
+    h_full = np.zeros(2 * n_qudits, dtype=int)
+    qudits_array = np.asarray(qudit_indices, dtype=int)
+    row_indices = np.concatenate([qudit_indices, n_qudits + qudits_array])
 
     # Embed phase vector
     h_full[row_indices] = phase_vector_local
 
-    return F_full, h_full
+    return h_full
 
 
 def _multi_index_to_linear(index: list[int] | np.ndarray, dims: list[int] | np.ndarray) -> int:

--- a/src/sympleq/models/random_hamiltonian.py
+++ b/src/sympleq/models/random_hamiltonian.py
@@ -181,13 +181,13 @@ def random_pauli_symmetry_hamiltonian(n_qudits: int, n_paulis: int, n_redundant=
 
     P = PauliSum.from_string(pauli_strings, dimensions=[2] * n_qudits, weights=weights, phases=phases)
 
-    g = Gate.from_random(n_qudits, 2)
-    P = g.act(P)
+    g = Gate.from_random(n_qudits)
+    P = g.act(P, 2)
 
     return P
 
 
-def random_gate_symmetric_hamiltonian(G: 'Gate',
+def random_gate_symmetric_hamiltonian(G: Gate,
                                       n_qudits: int | None = None,
                                       n_paulis: int | None = None,
                                       weight_mode: str = 'uniform',
@@ -218,12 +218,14 @@ def random_gate_symmetric_hamiltonian(G: 'Gate',
     with zero weight are removed.
     """
     if n_qudits is None:
-        n_qudits = len(G.qudit_indices) + 1
+        n_qudits = G.n_qudits()
     if n_paulis is None:
         n_paulis = 2 * n_qudits
     P = random_pauli_symmetry_hamiltonian(n_qudits, n_paulis, 0, 0, weight_mode=weight_mode)
+
+    qudits = tuple(np.random.randint(0, P.n_qudits(), size=G.n_qudits()).tolist())
     G_inv = G.inverse()
-    P_prime = G_inv.act(P)
+    P_prime = G_inv.act(P, qudits)
     P_sym = P + P_prime
     P_sym.phase_to_weight()
     P_sym.combine_equivalent_paulis()
@@ -231,6 +233,6 @@ def random_gate_symmetric_hamiltonian(G: 'Gate',
     P_sym.remove_zero_weight_paulis()
     if scrambled is True:
         g = Gate.from_random(n_qudits, 2)
-        P_sym = g.act(P_sym)
+        P_sym = g.act(P_sym, qudits)
 
     return P_sym

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from sympleq.core.circuits.gates import Hadamard
+from sympleq.core.circuits.gates import GATES
 from sympleq.core.paulis.pauli_string import PauliString
 from sympleq.core.paulis.pauli_sum import PauliSum
 
@@ -86,11 +86,9 @@ def test_hadamard_paulisum_benchmark(benchmark):
     n_qudits = 100
     dimensions = np.random.randint(2, 8, size=n_qudits)
 
-    gate = Hadamard(0, dimensions[0], inverse=False)
-
-    ps = PauliSum.from_random(n_paulis, dimensions, rand_weights=True)
+    ps = PauliSum.from_random(n_paulis, dimensions)
 
     def apply_gate():
-        _ = gate.act(ps)
+        _ = GATES.H.act(ps, np.random.randint(0, n_qudits))
 
     benchmark(apply_gate)

--- a/tests/core_tests/cirucits_tests/circuits_test.py
+++ b/tests/core_tests/cirucits_tests/circuits_test.py
@@ -53,24 +53,41 @@ class TestCircuits():
         # TODO: Full test for mixed dimensions
         for _ in range(10):
             n_qudits = 3
-            dimensions = 2
-            n_gates = 15
+            dimensions = [2, 3, 5]
+            n_gates = 4
             n_paulis = 5
             circuit = Circuit.from_random(n_qudits, n_gates)
-            pauli_sum = PauliSum.from_random(n_paulis, [dimensions] * n_qudits)
+
+            # circuit = Circuit.from_data([
+            #     (GATES.sum, 0, 2),
+            #     (GATES.sum, 2, 0),
+            #     (GATES.S, 0)
+            # ])
+
+            circuit = Circuit.from_data([
+                (GATES.S, 1),
+                (GATES.H, 1),
+                # (GATES.H, 2)
+            ])
+
+            print(circuit)
+
+            pauli_sum = PauliSum.from_random(n_paulis, dimensions)
             # compose the circuit and pauli sum
             composed_gate = circuit.composite_gate()
-            print(composed_gate.symplectic)
-            # FIXME: how to get qudits we re acting on?
-            qudits = tuple(q for q in range(pauli_sum.n_qudits()))
-            output_composite = composed_gate.act(pauli_sum, qudits)
+            affected_qudits = circuit.affected_qudits()
+            print("AFFECTED QUBITS", affected_qudits)
+            output_composite = composed_gate.act(pauli_sum, affected_qudits)
             output_sequential = circuit.act(pauli_sum)
-
+            if output_composite != output_sequential:
+                print("PHASE VECTORS")
+                print(composed_gate._phase_vectors)
+                print(circuit)
             # show that the composed gate returns the same thing as the circuit when acting on the pauli sum
             assert output_composite == output_sequential, (
-                f'Input: \n {pauli_sum}\n'
-                f'Composed gate:\n{output_composite} \n'
-                f'Sequential gate:\n{output_sequential}'
+                # f'Input: \n{pauli_sum} \n'
+                # f'Composed gate:\n{output_composite} \n'
+                # f'Sequential gate:\n{output_sequential}'
             )
 
     def test_hadamard_composition(self):
@@ -88,14 +105,10 @@ class TestCircuits():
         # NOTE: the phase of the composite gate has not been reduced modulo 2*lcm yet
         composed_gate = circuit.composite_gate()
         qudits = tuple(q for q in range(pauli_sum.n_qudits()))
+        print("QUDITS", qudits)
 
         output_composite = composed_gate.act(pauli_sum, qudits)
         output_sequential = circuit.act(pauli_sum)
-
-        # print(output_composite)
-        # print(output_sequential)
-
-        print(qudits)
 
         # show that the composed gate returns the same thing as the circuit when acting on the pauli sum
         assert output_composite == output_sequential
@@ -128,7 +141,7 @@ class TestCircuits():
         N = 100
         dimensions = [2, 3, 5]
         n_paulis = 1
-        n_qudits = 3
+        n_qudits = len(dimensions)
         for _ in range(N):
             P = PauliSum.from_random(n_paulis, dimensions, rand_weights=False)
             C = Circuit.from_random(n_qudits, depth=np.random.randint(1, 6))
@@ -140,7 +153,7 @@ class TestCircuits():
             ps_res_m = ps_res.to_hilbert_space()
             phase_symplectic = ps_res.phases()[0]
 
-            ps_res.set_phases([0])
+            ps_res.set_phases([0] * n_paulis)
             ps_res_m = ps_res.to_hilbert_space().toarray()
             ps_m_res = (U @ ps_m @ U.conj().T).toarray()
             mask = (ps_res_m != 0)
@@ -154,10 +167,11 @@ class TestCircuits():
 
     def test_phase_mixed_species(self):
         def debug_steps(C: Circuit, P: PauliSum):
-            print(f"Initial phases: {P.phases} -- exponents: {P.tableau()}")
+            print(f"CIRCUIT {C}")
+            print(f"Initial phases: {P.phases()} -- exponents: {P.tableau()}")
             for i, partial_p in enumerate(C.act_iter(P)):
                 gate = C.gates()[i]
-                print(f"Phases after {gate.name}: {partial_p.phases} -- exponents: {partial_p.tableau()}")
+                print(f"Phases after {gate.name()}: {partial_p.phases()} -- exponents: {partial_p.tableau()}")
 
         # Test 1: Simple qutrit + qubit
         P = PauliSum.from_string(['x2z0 x0z0'],
@@ -200,7 +214,7 @@ class TestCircuits():
         P = C.act(P)
         assert P.phases()[0] == 6
 
-        # Test 5: Simple qutritt + qubit but action on qubit
+        # Test 5: Simple qutrit + qubit but action on qubit
         P = PauliSum.from_string(['x0z0 x1z0'],
                                  dimensions=[3, 2],
                                  weights=[1], phases=[0])

--- a/tests/core_tests/cirucits_tests/circuits_test.py
+++ b/tests/core_tests/cirucits_tests/circuits_test.py
@@ -1,5 +1,6 @@
+from sympleq.core.circuits.gates import GATES
 from sympleq.core.circuits.known_circuits import to_x, to_ix
-from sympleq.core.circuits import Circuit, SUM, SWAP, Hadamard, PHASE
+from sympleq.core.circuits import Circuit
 from sympleq.core.paulis import PauliSum, PauliString
 import numpy as np
 from scipy.sparse import issparse
@@ -48,69 +49,19 @@ class TestCircuits():
         print(list_of_failures)
         assert len(list_of_failures) == 0
 
-    def random_pauli_sum(self, dim: int, n_qudits: int, n_paulis: int = 10) -> PauliSum:
-        # Generates a random PauliSum with n_paulis random PauliStrings of dimension dim
-        # FIXME: there is no guarantee at the moment that it is always possible to have
-        #        n_paulis distinct PauliStrings for arbitrary dimensions and n_qudits.
-        ps_list = [self.random_pauli_string(dim, n_qudits) for _ in range(n_paulis)]
-        return PauliSum.from_pauli_strings(ps_list).to_standard_form()
-
-    def random_pauli_string(self, dim: int, n_qudits: int) -> PauliString:
-        # Generates a random PauliString of dimension dim, discarding identity.
-        while True:
-            string = ''
-            for _ in range(n_qudits):
-                r = np.random.randint(0, dim)
-                s = np.random.randint(0, dim)
-                string += f'x{r}z{s} '
-            ps = PauliString.from_string(string, dimensions=[dim] * n_qudits)
-            if not ps.is_identity():
-                return ps
-
-    def make_random_circuit(self, n_gates, n_qudits, dimension) -> Circuit:
-        dimensions = [dimension] * n_qudits
-        gates_list = []
-        for _ in range(n_gates):
-            gate_int = np.random.randint(0, 4)
-            if gate_int == 0:
-                gate = Hadamard(np.random.randint(0, n_qudits), dimension)
-            elif gate_int == 1:
-                gate = PHASE(np.random.randint(0, n_qudits), dimension)
-            elif gate_int == 2:
-                # two random non-equal numbers
-                q1, q2 = np.random.randint(0, n_qudits, 2)
-                while q1 == q2:
-                    q1, q2 = np.random.randint(0, n_qudits, 2)
-                gate = SUM(q1, q2, dimension)
-            else:
-                q1, q2 = np.random.randint(0, n_qudits, 2)
-                while q1 == q2:
-                    q1, q2 = np.random.randint(0, n_qudits, 2)
-                gate = SWAP(q1, q2, dimension)
-            if gate == SUM or gate == SWAP:
-                gates_list.append(gate)
-            else:
-                gates_list.append(gate)
-
-        return Circuit(dimensions, gates_list)
-
     def test_circuit_composition(self):
         # TODO: Full test for mixed dimensions
         for _ in range(10):
             n_qudits = 3
-            dimension = 2
+            dimensions = 2
             n_gates = 15
             n_paulis = 5
-            # make a random circuit
-            circuit = self.make_random_circuit(n_gates, n_qudits, dimension)
-            print(circuit)
-
-            # make a random pauli sum
-            pauli_sum = self.random_pauli_sum(dimension, n_qudits, n_paulis=n_paulis)
-            print(dimension)
+            circuit = Circuit.from_random(n_qudits, n_gates)
+            pauli_sum = PauliSum.from_random(n_paulis, [dimensions] * n_qudits)
             # compose the circuit and pauli sum
             composed_gate = circuit.composite_gate()
             print(composed_gate.symplectic)
+            # FIXME: how to get qudits we re acting on?
             output_composite = composed_gate.act(pauli_sum)
             output_sequential = circuit.act(pauli_sum)
 
@@ -125,13 +76,12 @@ class TestCircuits():
         # simple case of two Hadamards on different qubits. Known symplectic in this case.
 
         n_qudits = 1
-        dimension = 2
+        dimensions = 2
         n_paulis = 2
-        # make a random circuit
-        circuit = Circuit([dimension] * n_qudits, [Hadamard(0, dimension), PHASE(0, dimension)])
+        circuit = Circuit.from_data([(GATES.H, 0), (GATES.S, 0)])
 
         # make a random pauli sum
-        pauli_sum = self.random_pauli_sum(dimension, n_qudits, n_paulis=n_paulis)
+        pauli_sum = PauliSum.from_random(n_paulis, [dimensions] * n_qudits)
 
         # compose the circuit and pauli sum
         composed_gate = circuit.composite_gate()
@@ -153,7 +103,7 @@ class TestCircuits():
         for _ in range(1000):
             n_qudits = np.random.randint(2, 10)
             dimensions = np.random.randint(2, 5, size=n_qudits)
-            C = Circuit.from_random(n_qudits=n_qudits, depth=10, dimensions=dimensions)
+            C = Circuit.from_random(n_qudits, depth=10)
             ps = PauliSum.from_random(10, dimensions)
             out = C.act(ps)
             assert np.all(out.dimensions() == dimensions)
@@ -162,11 +112,12 @@ class TestCircuits():
         # For a single-qudit circuit with one Hadamard, the circuit unitary
         # should equal the gate's local unitary.
         for d in [2, 3, 5, 11]:
-            gate = Hadamard(0, d)
-            circuit = Circuit([d], [gate])
+            gate = GATES.H
+            qudit = np.random.randint(d, dtype=int)
+            circuit = Circuit.from_data((gate, qudit))
             U_circ = circuit.unitary()
             assert issparse(U_circ)
-            U_gate = gate.unitary()
+            U_gate = gate.unitary(qudit, d)
             assert U_circ.shape == U_gate.shape
             assert np.allclose(U_circ.toarray(), U_gate.toarray())
 
@@ -177,7 +128,7 @@ class TestCircuits():
         n_qudits = 3
         for _ in range(N):
             P = PauliSum.from_random(n_paulis, dimensions, rand_weights=False)
-            C = Circuit.from_random(n_qudits, depth=np.random.randint(1, 6), dimensions=dimensions)
+            C = Circuit.from_random(n_qudits, depth=np.random.randint(1, 6))
             U = C.unitary()
 
             ps_m = P.to_hilbert_space()
@@ -201,7 +152,7 @@ class TestCircuits():
         def debug_steps(C: Circuit, P: PauliSum):
             print(f"Initial phases: {P.phases} -- exponents: {P.tableau()}")
             for i, partial_p in enumerate(C.act_iter(P)):
-                gate = C.gates[i]
+                gate = C.gates()[i]
                 print(f"Phases after {gate.name}: {partial_p.phases} -- exponents: {partial_p.tableau()}")
 
         # Test 1: Simple qutrit + qubit
@@ -209,7 +160,7 @@ class TestCircuits():
                                  dimensions=[3, 2],
                                  weights=[1], phases=[0])
         idx = 0
-        C = Circuit(dimensions=P.dimensions(), gates=[PHASE(idx, P.dimensions()[idx])])
+        C = Circuit.from_data((GATES.S, idx))
         debug_steps(C, P)
         P = C.act(P)
         assert P.phases()[0] == 4
@@ -220,7 +171,7 @@ class TestCircuits():
                                  weights=[1], phases=[0])
 
         idx = 0
-        C = Circuit(dimensions=P.dimensions(), gates=[PHASE(idx, P.dimensions()[idx])])
+        C = Circuit.from_data((GATES.S, idx))
         debug_steps(C, P)
         P = C.act(P)
         assert P.phases()[0] == 4
@@ -230,7 +181,7 @@ class TestCircuits():
                                  dimensions=[5, 2],
                                  weights=[1], phases=[0])
         idx = 0
-        C = Circuit(dimensions=P.dimensions(), gates=[PHASE(idx, P.dimensions()[idx])])
+        C = Circuit.from_data((GATES.S, idx))
         debug_steps(C, P)
         P = C.act(P)
         assert P.phases()[0] == 12
@@ -240,7 +191,7 @@ class TestCircuits():
                                  dimensions=[5, 3],
                                  weights=[1], phases=[0])
         idx = 0
-        C = Circuit(dimensions=P.dimensions(), gates=[PHASE(idx, P.dimensions()[idx])])
+        C = Circuit.from_data((GATES.S, idx))
         debug_steps(C, P)
         P = C.act(P)
         assert P.phases()[0] == 6
@@ -250,7 +201,7 @@ class TestCircuits():
                                  dimensions=[3, 2],
                                  weights=[1], phases=[0])
         idx = 1
-        C = Circuit(dimensions=P.dimensions(), gates=[PHASE(idx, P.dimensions()[idx])])
+        C = Circuit.from_data((GATES.S, idx))
         debug_steps(C, P)
         P = C.act(P)
         assert P.phases()[0] == 3
@@ -260,7 +211,7 @@ class TestCircuits():
                                  dimensions=[5, 3, 2],
                                  weights=[1], phases=[0])
         idx = 0
-        C = Circuit(dimensions=P.dimensions(), gates=[PHASE(idx, P.dimensions()[idx])])
+        C = Circuit.from_data((GATES.S, idx))
         debug_steps(C, P)
         P = C.act(P)
         assert P.phases()[0] == 12
@@ -270,10 +221,7 @@ class TestCircuits():
                                  dimensions=[3, 2],
                                  weights=[1], phases=[0])
         idx = 0
-        C = Circuit(dimensions=P.dimensions(), gates=[
-            PHASE(idx, P.dimensions()[idx]),
-            PHASE(idx, P.dimensions()[idx]),
-            Hadamard(idx, P.dimensions()[idx])])
+        C = Circuit.from_data([(GATES.S, idx), (GATES.S, idx), (GATES.H, idx)])
         debug_steps(C, P)
         P = C.act(P)
         assert P.phases()[0] == 8
@@ -289,7 +237,7 @@ class TestCircuits():
     def test_swap_embedding_on_equal_dims(self):
         # Verify SWAP on qudits (0,1) within a 2-qudit system with equal dimensions.
         dims = [3, 3]
-        c = Circuit(dims, [SWAP(0, 1, 3)])
+        c = Circuit.from_data((GATES.swap, 0, 1))
         U = c.unitary()
 
         # Start in |i,j> with i=1, j=2
@@ -309,7 +257,7 @@ class TestCircuits():
         # Verify SUM on qudits (1,2) inside a 3-qudit system.
         d = 5
         dims = [d, d, d]
-        c = Circuit(dims, [SUM(1, 2, d)])
+        c = Circuit.from_data((GATES.sum, 1, 2))
         U = c.unitary()
 
         # Start in |i,j,k> = |3,1,4>
@@ -329,7 +277,7 @@ class TestCircuits():
         # Verify PHASE acting on middle qudit multiplies amplitude appropriately.
         d0, d1, d2 = 3, 5, 2
         dims = [d0, d1, d2]
-        c = Circuit(dims, [PHASE(1, d1)])
+        c = Circuit.from_data((GATES.S, 1))
         U = c.unitary()
 
         # Basis |i,j,k> = |2,3,1>

--- a/tests/core_tests/cirucits_tests/circuits_test.py
+++ b/tests/core_tests/cirucits_tests/circuits_test.py
@@ -1,4 +1,4 @@
-from sympleq.core.circuits.gates import GATES
+from sympleq.core.circuits import GATES
 from sympleq.core.circuits.known_circuits import to_x, to_ix
 from sympleq.core.circuits import Circuit
 from sympleq.core.paulis import PauliSum, PauliString
@@ -62,7 +62,8 @@ class TestCircuits():
             composed_gate = circuit.composite_gate()
             print(composed_gate.symplectic)
             # FIXME: how to get qudits we re acting on?
-            output_composite = composed_gate.act(pauli_sum)
+            qudits = tuple(q for q in range(pauli_sum.n_qudits()))
+            output_composite = composed_gate.act(pauli_sum, qudits)
             output_sequential = circuit.act(pauli_sum)
 
             # show that the composed gate returns the same thing as the circuit when acting on the pauli sum
@@ -76,7 +77,7 @@ class TestCircuits():
         # simple case of two Hadamards on different qubits. Known symplectic in this case.
 
         n_qudits = 1
-        dimensions = 2
+        dimensions = 2  # FIXME: this fails only for dimensions = 2
         n_paulis = 2
         circuit = Circuit.from_data([(GATES.H, 0), (GATES.S, 0)])
 
@@ -84,16 +85,17 @@ class TestCircuits():
         pauli_sum = PauliSum.from_random(n_paulis, [dimensions] * n_qudits)
 
         # compose the circuit and pauli sum
+        # NOTE: the phase of the composite gate has not been reduced modulo 2*lcm yet
         composed_gate = circuit.composite_gate()
-        output_composite = composed_gate.act(pauli_sum)
+        qudits = tuple(q for q in range(pauli_sum.n_qudits()))
+
+        output_composite = composed_gate.act(pauli_sum, qudits)
         output_sequential = circuit.act(pauli_sum)
 
-        # print(composed_gate.symplectic)
+        # print(output_composite)
+        # print(output_sequential)
 
-        # print((Hadamard(0, dimension).symplectic.T @ PHASE(0, dimension).symplectic.T).T)
-
-        print(output_composite)
-        print(output_sequential)
+        print(qudits)
 
         # show that the composed gate returns the same thing as the circuit when acting on the pauli sum
         assert output_composite == output_sequential
@@ -112,12 +114,13 @@ class TestCircuits():
         # For a single-qudit circuit with one Hadamard, the circuit unitary
         # should equal the gate's local unitary.
         for d in [2, 3, 5, 11]:
+            dimensions = np.asarray([d], dtype=int)  # single-qudit circuit
             gate = GATES.H
             qudit = np.random.randint(d, dtype=int)
             circuit = Circuit.from_data((gate, qudit))
-            U_circ = circuit.unitary()
+            U_circ = circuit.unitary(dimensions)
             assert issparse(U_circ)
-            U_gate = gate.unitary(qudit, d)
+            U_gate = gate.unitary(qudit, dimensions)
             assert U_circ.shape == U_gate.shape
             assert np.allclose(U_circ.toarray(), U_gate.toarray())
 
@@ -129,23 +132,24 @@ class TestCircuits():
         for _ in range(N):
             P = PauliSum.from_random(n_paulis, dimensions, rand_weights=False)
             C = Circuit.from_random(n_qudits, depth=np.random.randint(1, 6))
-            U = C.unitary()
+            print("RANDOM C", C)
+            U = C.unitary(dimensions=P.dimensions())
 
             ps_m = P.to_hilbert_space()
             ps_res = C.act(P)
             ps_res_m = ps_res.to_hilbert_space()
             phase_symplectic = ps_res.phases()[0]
 
-            # FIXME: maybe create a new PauliSum, or add API to assign phases
             ps_res.set_phases([0])
             ps_res_m = ps_res.to_hilbert_space().toarray()
             ps_m_res = (U @ ps_m @ U.conj().T).toarray()
             mask = (ps_res_m != 0)
             factors = np.unique(np.around(ps_m_res[mask] / ps_res_m[mask], 10))
+            print("FACTORS", factors)
             assert len(factors) == 1
             factor = factors[0]
-            d = P.lcm()
-            phase_unitary = int(np.around((d * np.angle(factor) / (np.pi)) % (2 * d), 1))
+            lcm = P.lcm()
+            phase_unitary = int(np.around((lcm * np.angle(factor) / (np.pi)) % (2 * lcm), 1))
             assert phase_symplectic == phase_unitary
 
     def test_phase_mixed_species(self):
@@ -238,7 +242,7 @@ class TestCircuits():
         # Verify SWAP on qudits (0,1) within a 2-qudit system with equal dimensions.
         dims = [3, 3]
         c = Circuit.from_data((GATES.swap, 0, 1))
-        U = c.unitary()
+        U = c.unitary(dims)
 
         # Start in |i,j> with i=1, j=2
         i, j = 1, 2
@@ -258,7 +262,7 @@ class TestCircuits():
         d = 5
         dims = [d, d, d]
         c = Circuit.from_data((GATES.sum, 1, 2))
-        U = c.unitary()
+        U = c.unitary(dims)
 
         # Start in |i,j,k> = |3,1,4>
         i, j, k = 3, 1, 4
@@ -278,7 +282,7 @@ class TestCircuits():
         d0, d1, d2 = 3, 5, 2
         dims = [d0, d1, d2]
         c = Circuit.from_data((GATES.S, 1))
-        U = c.unitary()
+        U = c.unitary(dims)
 
         # Basis |i,j,k> = |2,3,1>
         i, j, k = 2, 3, 1

--- a/tests/core_tests/cirucits_tests/gates_test.py
+++ b/tests/core_tests/cirucits_tests/gates_test.py
@@ -1,11 +1,13 @@
 import numpy as np
 import random
 
-from sympleq.core.circuits import SUM, SWAP, Hadamard, PHASE, Gate, Circuit
+from sympleq.core.circuits import Gate, Circuit
+from sympleq.core.circuits.gates import GATES
 from sympleq.core.circuits.utils import is_symplectic
 from sympleq.core.paulis import PauliSum, PauliString
 from sympleq.core.circuits.random_symplectic import symplectic_gf2, \
     symplectic_group_size, symplectic_random_transvection
+from sympleq.core.paulis.constants import DEFAULT_QUDIT_DIMENSION
 
 
 class TestGates():
@@ -21,19 +23,6 @@ class TestGates():
                                       'x1z1 x1z0 x0z0'], dimensions=[dim, dim, dim])
         return ps1, ps2, ps3, ps4, ps5, p_sum
 
-    def random_pauli_sum(self, dim, n_paulis=10):
-        # Generates a random PauliSum with n_paulis random PauliStrings of dimension dim
-        #
-        ps_list = []
-        element_list = [(0, 0, 0, 0)]  # to keep track of already generated PauliStrings. Avoids identity and duplicates
-        for _ in range(n_paulis):
-            ps, r1, r2, s1, s2 = self.random_pauli_string(dim)
-            element_list.append((r1, r2, s1, s2))
-            while (r1, r2, s1, s2) in element_list:
-                ps, r1, r2, s1, s2 = self.random_pauli_string(dim)
-            ps_list.append(ps)
-        return PauliSum.from_pauli_strings(ps_list)
-
     def random_pauli_string(self, dim):
         # Generates a random PauliString of dimension dim
         r1 = np.random.randint(0, dim)
@@ -43,7 +32,7 @@ class TestGates():
         return PauliString.from_string(f'x{r1}z{s1} x{r2}z{s2}', dimensions=[dim, dim]), r1, r2, s1, s2
 
     def test_SUM(self):
-        # acts the SUM gate on a bunch of random pauli strings and pauli sums
+        # acts the GATES.sum gate on a bunch of random pauli strings and pauli sums
         for d in [2, 5, 11]:
             # test pauli_strings
             for i in range(1000):
@@ -56,8 +45,9 @@ class TestGates():
                 output_str_correct = f"x{r1}z{(s1 - s2) % d} x{(r2 + r1) % d}z{s2}"
 
                 input_ps = PauliString.from_string(input_str, dimensions=[d, d])
-                output_ps = SUM(0, 1, d).act(input_ps)
-                assert output_ps == PauliString.from_string(output_str_correct, dimensions=[d, d]), 'Error in SUM gate'
+                output_ps = GATES.sum.act(input_ps, (0, 1))
+                assert output_ps == PauliString.from_string(output_str_correct, dimensions=[
+                                                            d, d]), 'Error in GATES.sum gate'
 
             # test pauli_sums
             for i in range(10):
@@ -82,15 +72,15 @@ class TestGates():
                 input_psum = PauliSum.from_pauli_strings(ps_list_in)
                 output_psum_correct = PauliSum.from_pauli_strings(ps_list_out_correct, phases=ps_phase_out_correct)
 
-                output_psum = SUM(0, 1, d).act(input_psum)
+                output_psum = GATES.sum.act(input_psum, (0, 1))
                 assert output_psum == output_psum_correct, (
-                    'Error in SUM gate: \n' +
+                    'Error in GATES.sum gate: \n' +
                     output_psum.__str__() + '\n' +
                     output_psum_correct.__str__()
                 )
 
     def test_SWAP(self):
-        # acts the SUM gate on a bunch of random pauli strings and pauli sums
+        # acts the GATES.sum gate on a bunch of random pauli strings and pauli sums
         # C = np.array([[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
         # U = np.zeros((4, 4), dtype=int)
         # U[2:, :2] = np.eye(2, dtype=int)
@@ -106,11 +96,12 @@ class TestGates():
                 output_str_correct = f"x{r2}z{(s2) % d} x{r1}z{s1}"
 
                 input_ps = PauliString.from_string(input_str, dimensions=[d, d])
-                output_ps = SWAP(0, 1, d).act(input_ps)
-                assert output_ps == PauliString.from_string(output_str_correct, dimensions=[d, d]), 'Error in SUM gate'
+                output_ps = GATES.swap.act(input_ps, (0, 1))
+                assert output_ps == PauliString.from_string(output_str_correct, dimensions=[
+                                                            d, d]), 'Error in GATES.sum gate'
 
             # test pauli_sums
-            for i in range(100):
+            for _ in range(100):
                 ps_list_in = []
                 ps_list_out_correct = []
                 ps_phase_out_correct = []
@@ -137,9 +128,9 @@ class TestGates():
                 output_psum_correct = PauliSum.from_pauli_strings(ps_list_out_correct,
                                                                   phases=ps_phase_out_correct)
 
-                output_psum = SWAP(0, 1, d).act(input_psum)
+                output_psum = GATES.swap.act(input_psum, (0, 1))
                 assert output_psum == output_psum_correct, (
-                    'Error in SUM gate: \n' +
+                    'Error in GATES.sum gate: \n' +
                     input_psum.__str__() + '\n' +
                     output_psum.__str__() + '\n' +
                     output_psum_correct.__str__()
@@ -148,35 +139,30 @@ class TestGates():
     def test_Hadamard(self):
         # TODO: Be certain of inverse convention - ultimately arbitrary but should match prevalent literature
         for d in [2, 5, 11]:
-            # test pauli_strings
-            gate = Hadamard(0, d, inverse=False)  # Hadamard on qubit 0
-
-            for i in range(100):
+            for _ in range(100):
                 input_ps, r1, r2, s1, s2 = self.random_pauli_string(d)
                 output_str_correct = f"x{(-s1) % d}z{r1} x{r2}z{s2}"
 
-                output_ps = gate.act(input_ps)
+                output_ps = GATES.H.act(input_ps, 0)
                 assert output_ps == PauliString.from_string(
                     output_str_correct, dimensions=[d, d]
-                ), 'Error in Hadamard gate 0'
+                ), 'Error in GATES.H gate 0'
 
-            gate = Hadamard(1, d, inverse=False)  # Hadamard on qudit 1
-            for i in range(100):
+            for _ in range(100):
                 input_ps, r1, r2, s1, s2 = self.random_pauli_string(d)
                 output_str_correct = f"x{r1}z{s1} x{(-s2) % d}z{r2}"
 
-                output_ps = gate.act(input_ps)
+                output_ps = GATES.H.act(input_ps, 1)
                 assert output_ps == PauliString.from_string(
                     output_str_correct, dimensions=[d, d]
-                ), 'Error in Hadamard gate 1'
-            # test pauli_sums
-            gate = Hadamard(0, d, inverse=False)  # Hadamard on qubit 0
+                ), 'Error in GATES.H gate 1'
 
-            for i in range(100):
+            # test pauli_sums
+            for _ in range(100):
                 ps_list_in = []
                 ps_list_out_correct = []
                 ps_phase_out_correct = []
-                for j in range(10):
+                for _ in range(10):
                     input_ps, r1, r2, s1, s2 = self.random_pauli_string(d)
                     output_str_correct = f"x{(-s1) % d}z{r1} x{r2}z{s2}"
 
@@ -185,44 +171,43 @@ class TestGates():
                     ps_phase_out_correct.append(-2 * r1 * s1)
 
                 input_psum = PauliSum.from_pauli_strings(ps_list_in)
-                output_psum = gate.act(input_psum)
+                output_psum = GATES.H.act(input_psum, 0)
                 output_psum_correct = PauliSum.from_pauli_strings(
                     ps_list_out_correct, phases=ps_phase_out_correct)
                 assert output_psum == output_psum_correct, (
-                    'Error in Hadamard gate: \n' +
+                    'Error in GATES.H gate: \n' +
                     input_psum.__str__() + '\n' +
                     output_psum.__str__() + '\n' +
                     output_psum_correct.__str__()
                 )
 
     def test_PHASE(self):
-        # TODO: Better approach - is there another approach that we can test the first one with like Hadamard?
+        # TODO: Better approach - is there another approach that we can test the first one with like GATES.H?
         for d in [2, 5, 11]:
-            gate = PHASE(0, d)  # PHASE on qubit 0
 
             for i in range(100):
                 input_ps, r1, r2, s1, s2 = self.random_pauli_string(d)
                 output_str_correct = f"x{r1}z{(r1 + s1) % d} x{r2}z{s2}"
 
-                output_ps = gate.act(input_ps)
+                output_ps = GATES.phase.act(input_ps, 0)
                 assert output_ps == PauliString.from_string(output_str_correct, dimensions=[d, d]), 'Error in H gate 0'
 
-            gate = PHASE(1, d)  # PHASE on qudit 1
             for i in range(100):
                 input_ps, r1, r2, s1, s2 = self.random_pauli_string(d)
                 output_str_correct = f"x{r1}z{s1} x{r2}z{(r2 + s2) % d}"
 
-                output_ps = gate.act(input_ps)
+                output_ps = GATES.phase.act(input_ps, 1)
                 assert output_ps == PauliString.from_string(output_str_correct, dimensions=[d, d]), 'Error in H gate 1'
+
             # test pauli_sums
-            gate = PHASE(0, d)  # PHASE on qubit 0
-            h = gate.phase_vector
-            C = gate.symplectic
+            gate = GATES.phase
+            h = gate.phase_vector(d)
+            C = gate.symplectic()
             for i in range(100):
                 ps_list_in = []
                 ps_list_out_correct = []
                 ps_phase_out_correct = []
-                for j in range(10):
+                for _ in range(10):
                     input_ps, r1, r2, s1, s2 = self.random_pauli_string(d)
                     output_str_correct = f"x{r1}z{(r1 + s1) % d} x{r2}z{s2}"
 
@@ -232,7 +217,7 @@ class TestGates():
                     U = np.zeros((input_ps.n_qudits(), input_ps.n_qudits()), dtype=int)
                     U[1, 0] = 1
 
-                    p = (
+                    p = int(
                         np.dot(h, a1) -
                         np.diag(C.T @ U @ C) @ a1 +
                         2 * a1 @ np.triu(C.T @ U @ C) @ a1 -
@@ -241,11 +226,12 @@ class TestGates():
                     ps_phase_out_correct.append(p)
 
                 input_psum = PauliSum.from_pauli_strings(ps_list_in)
-                output_psum = gate.act(input_psum)
+                output_psum = gate.act(input_psum, 0)
                 output_psum_correct = PauliSum.from_pauli_strings(
                     ps_list_out_correct, phases=ps_phase_out_correct)
+
                 assert output_psum == output_psum_correct, (
-                    'Error in Hadamard gate: \n' +
+                    'Error in GATES.H gate: \n' +
                     input_psum.__str__() + '\n' +
                     output_psum.__str__() + '\n' +
                     output_psum_correct.__str__()
@@ -255,11 +241,12 @@ class TestGates():
         # Tests all gates and all combinations of two pauli strings for the group homomorphism property:
         # gate.act(p1) * gate.act(p2) == gate.act(p1 * p2)
 
-        gates = [SUM(0, 1, 2), SUM(1, 0, 2), SWAP(0, 1, 2), Hadamard(0, 2), Hadamard(1, 2), PHASE(0, 2), PHASE(1, 2)]  #
+        gates_data = [(GATES.sum, 0, 1), (GATES.sum, 1, 0), (GATES.swap, 0, 1),
+                      (GATES.H, 0), (GATES.H, 1), (GATES.phase, 0), (GATES.phase, 1)]
         i = 0
 
         # test all for dim = 2
-        for gate in gates:
+        for (gate, *qudits) in gates_data:
             for x0 in range(2):
                 for z0 in range(2):
                     for x1 in range(2):
@@ -274,32 +261,31 @@ class TestGates():
                                             err0 = 'In: \n' + p1.__str__() + '\n' + p2.__str__()
                                             err = (
                                                 'Out: \n' +
-                                                (gate.act(p1) * gate.act(p2)).__str__() +
+                                                (gate.act(p1, qudits) * gate.act(p2, qudits)).__str__() +
                                                 '\n' +
-                                                gate.act(p1 * p2).__str__()
+                                                gate.act(p1 * p2, qudits).__str__()
                                             )
-                                            assert gate.act(p1) * gate.act(p2) == gate.act(p1 * p2), err0 + err + '\n'
+                                            assert gate.act(p1, qudits) * \
+                                                gate.act(p2, qudits) == gate.act(p1 * p2, qudits), err0 + err + '\n'
 
-        for dim in [3, 5, 7, 15]:
-            gates = [SUM(0, 1, dim), SUM(1, 0, dim), SWAP(0, 1, dim), Hadamard(0, dim),
-                     Hadamard(1, dim), PHASE(0, dim), PHASE(1, dim)]
-            for gate in gates:
-
+        for dimensions in [3, 5, 7, 15]:
+            for (gate, *qudits) in gates_data:
                 for _ in range(100):
-                    p1 = self.random_pauli_sum(dim, n_paulis=1)
-                    p2 = self.random_pauli_sum(dim, n_paulis=1)
+                    p1 = PauliSum.from_random(1, [dimensions] * 2)
+                    p2 = PauliSum.from_random(1, [dimensions] * 2)
                     err0 = 'In: \n' + p1.__str__() + '\n' + p2.__str__()
-                    err = 'Out: \n' + (gate.act(p1) * gate.act(p2)).__str__() + '\n' + gate.act(p1 * p2).__str__()
-                    assert gate.act(p1) * gate.act(p2) == gate.act(p1 * p2), err0 + err + '\n'
+                    err = 'Out: \n' + (gate.act(p1, qudits) * gate.act(p2, qudits)
+                                       ).__str__() + '\n' + gate.act(p1 * p2, qudits).__str__()
+                    assert gate.act(p1, qudits) * gate.act(p2, qudits) == gate.act(p1 * p2, qudits), err0 + err + '\n'
 
     def test_is_symplectic(self):
-
         # Tests if the symplectic matrix of the gate is symplectic
-        gates = [SUM(0, 1, 2), SWAP(0, 1, 2), Hadamard(0, 2), Hadamard(1, 2), PHASE(0, 2), PHASE(1, 2)]
-        for gate in gates:
-            assert is_symplectic(gate.symplectic, 2), (
-                f"Gate {gate.name} is not symplectic. \n" +
-                gate.symplectic.__str__()
+        gates_data = [(GATES.sum, 0, 1), (GATES.swap, 0, 1), (GATES.H, 0),
+                      (GATES.H, 1), (GATES.phase, 0), (GATES.phase, 1)]
+        for (gate, *qudits) in gates_data:
+            assert is_symplectic(gate.symplectic(), 2), (
+                f"Gate {gate.name()} is not symplectic. \n" +
+                gate.symplectic().__str__()
             )
 
     def test_random_symplectic(self, num_tests=20, max_n=10, primes=[2, 3, 5, 7]):
@@ -339,23 +325,24 @@ class TestGates():
         input_ps = PauliSum.from_random(n_paulis, dimensions=dimensions)
         input_ps.remove_trivial_paulis()
         input_ps.combine_equivalent_paulis()
-        print(input_ps)
-        circuit = Circuit.from_random(n_qudits, 100, dimensions)
+        print(input_ps.dimensions())
+        circuit = Circuit.from_random(n_qudits, 100)
         target_ps = circuit.act(input_ps)
-        # FIXME: create API to change phases and weights
+        print(target_ps.dimensions())
         target_ps.set_phases(np.zeros(n_paulis))
 
-        gate_from_solver = Gate.solve_from_target('ArbGate', input_ps, target_ps, dimensions)
-        output_ps = gate_from_solver.act(input_ps)
+        gate_from_solver = Gate.solve_from_target('ArbGate', input_ps, target_ps)
+        qudits = tuple(range(n_qudits))
+        output_ps = gate_from_solver.act(input_ps, qudits)
         output_ps.set_phases(np.zeros(n_paulis))
         assert output_ps == target_ps, (
             'Error in gate_from_solver\n input:\n' + input_ps.__str__() +
             '\n target:\n' + target_ps.__str__() + '\n output:\n' + output_ps.__str__())
 
-        for d in [2]:  # only solves on GF(2) for now...
+        for dimensions in [2]:  # only solves on GF(2) for now...
             for i in range(10):
-                input_ps = self.random_pauli_sum(d, n_paulis=6)
-                target_ps = self.random_pauli_sum(d, n_paulis=6)
+                input_ps = PauliSum.from_random(6, [dimensions] * n_qudits)
+                target_ps = PauliSum.from_random(6, [dimensions] * n_qudits)
 
                 if np.all(input_ps.symplectic_product_matrix() == target_ps.symplectic_product_matrix()):
                     print(i)
@@ -363,9 +350,10 @@ class TestGates():
                     print(input_ps.tableau())
                     print('target')
                     print(target_ps.tableau())
-                    gate = Gate.solve_from_target('ArbGate', input_ps, target_ps, dimensions)
-                    output_ps = gate.act(input_ps)
-                    output_ps.phases = input_ps.phases  # So far it does not solve for phases as well
+                    gate = Gate.solve_from_target('ArbGate', input_ps, target_ps)
+                    qudits = tuple(range(n_qudits))
+                    output_ps = gate.act(input_ps, qudits)
+                    output_ps.set_phases(input_ps.phases())  # So far it does not solve for phases as well
                     print('output')
                     print(output_ps.tableau())
                     print('gate')
@@ -387,7 +375,7 @@ class TestGates():
         for _ in range(100):
             g = Gate.from_random(5, 2)
             gt = g.transvection(np.random.randint(0, 1, size=10))
-            assert is_symplectic(gt.symplectic, 2), 'Error in transvection'
+            assert is_symplectic(gt.symplectic(), 2), 'Error in transvection'
 
     # def test_gate_inverse(self):
     #     n_qudits = 2
@@ -401,75 +389,79 @@ class TestGates():
     #         assert rps == g.act(gt.act(rps)), 'Inversion Error:\n' + \
     #               rps.__str__() + '\n' + g.act(gt.act(rps)).__str__()
 
-    def phase_table_local(self, G: Gate) -> tuple[np.ndarray, np.ndarray]:
-        d = G.dimensions[0]
-        phase_table_unitary = np.zeros((d, d))
-        phase_table_symplectic = np.zeros((d, d))
-        for i in range(d):
-            for j in range(d):
+    def phase_table_local(self, G: Gate, dimensions: int, *qudits: int) -> tuple[np.ndarray, np.ndarray]:
+        # dimensions = random.randint(DEFAULT_QUDIT_DIMENSION, 7)
+        lcm = np.lcm.reduce(dimensions)
+
+        phase_table_unitary = np.zeros((dimensions, dimensions))
+        phase_table_symplectic = np.zeros((dimensions, dimensions))
+        for i in range(dimensions):
+            for j in range(dimensions):
                 pauli_string = 'x' + str(i) + 'z' + str(j)
-                ps = PauliSum.from_string(pauli_string, d, weights=[1], phases=[0])
+                ps = PauliSum.from_string(pauli_string, dimensions, weights=[1], phases=[0])
                 ps_m = ps.to_hilbert_space()
 
-                ps_res = G.act(ps)
-                phase_table_symplectic[i, j] = ps_res.phases()[0] % (2 * d)
-                # FIXME: create new PSum or open API to change phases
+                ps_res = G.act(ps, qudits)
+                phase_table_symplectic[i, j] = ps_res.phases()[0] % (2 * lcm)
                 ps_res.set_phases([0])
                 ps_res_m = ps_res.to_hilbert_space().toarray()
 
-                ps_m_res = (G.unitary() @ ps_m @ G.unitary().conj().T).toarray()
+                # FIXME: accept non-list inputs in unitary
+                gate_unitary = G.unitary(qudits, [dimensions] * G.n_qudits())
+                ps_m_res = (gate_unitary @ ps_m @ gate_unitary.conj().T).toarray()
 
                 mask = (ps_res_m != 0)
                 factors = np.around(ps_m_res[mask] / ps_res_m[mask], 14)
                 factor = factors[0]
-                phase_table_unitary[i, j] = np.around(d * np.angle(factor) / (np.pi), 6) % (2 * d)
+                phase_table_unitary[i, j] = np.around(dimensions * np.angle(factor) / (np.pi), 6) % (2 * lcm)
 
         return phase_table_unitary, phase_table_symplectic
 
-    def phase_table_entangling(self, G: Gate) -> tuple[np.ndarray, np.ndarray]:
-        d = G.dimensions[0]
-        phase_table_unitary = np.zeros((d**2, d**2))
-        phase_table_symplectic = np.zeros((d**2, d**2))
-        U = G.unitary()
-        for i1 in range(d):
-            for j1 in range(d):
-                for i2 in range(d):
-                    for j2 in range(d):
+    def phase_table_entangling(self, G: Gate, *qudits: int) -> tuple[np.ndarray, np.ndarray]:
+        dimensions = random.randint(DEFAULT_QUDIT_DIMENSION, 7)
+        lcm = np.lcm.reduce(dimensions)
+
+        phase_table_unitary = np.zeros((dimensions**2, dimensions**2))
+        phase_table_symplectic = np.zeros((dimensions**2, dimensions**2))
+        U = G.unitary(qudits, [dimensions] * G.n_qudits())
+        for i1 in range(dimensions):
+            for j1 in range(dimensions):
+                for i2 in range(dimensions):
+                    for j2 in range(dimensions):
                         pauli_string = 'x' + str(i1) + 'z' + str(j1) + ' ' + 'x' + str(i2) + 'z' + str(j2)
-                        ps = PauliSum.from_string([pauli_string], dimensions=[d, d])
+                        ps = PauliSum.from_string([pauli_string], dimensions=[dimensions, dimensions])
                         ps_m = ps.to_hilbert_space()
 
-                        ps_res = G.act(ps)
-                        phase_table_symplectic[i1 * d + i2, j1 * d + j2] = ps_res.phases()[0] % (2 * d)
+                        ps_res = G.act(ps, qudits)
+                        phase_table_symplectic[i1 * dimensions + i2, j1 *
+                                               dimensions + j2] = ps_res.phases()[0] % (2 * lcm)
                         ps_res.set_phases([0])
                         ps_res_m = ps_res.to_hilbert_space().toarray()
                         ps_m_res = (U @ ps_m @ U.conj().T).toarray()
                         mask = (ps_res_m != 0)
                         factors = np.around(ps_m_res[mask] / ps_res_m[mask], 14)
                         factor = factors[0]
-                        phase_table_unitary[i1 * d + i2,
-                                            j1 * d + j2] = np.around(d * np.angle(factor) / (np.pi), 6) % (2 * d)
+                        phase_table_unitary[i1 * dimensions + i2, j1 * dimensions + j2] = \
+                            np.around(dimensions * np.angle(factor) / (np.pi), 6) % (2 * lcm)
 
         return phase_table_unitary, phase_table_symplectic
 
     def test_phase_table(self):
         for d in [2, 3, 5, 7]:  # 11, 13 These work as well, but it's very slow to run
-            G = Hadamard(0, d)
-            phase_table_unitary, phase_table_symplectic = self.phase_table_local(G)
+            phase_table_unitary, phase_table_symplectic = self.phase_table_local(GATES.H, d, 0)
             diff_m = np.around(phase_table_unitary - phase_table_symplectic, 10)
-            assert not np.any(diff_m), 'Symplectic phase table does not match unitary phase table for Hadamard gate'
+            assert not np.any(diff_m), 'Symplectic phase table does not match unitary phase table for GATES.H gate'
 
-            G = PHASE(0, d)
-            phase_table_unitary, phase_table_symplectic = self.phase_table_local(G)
+            phase_table_unitary, phase_table_symplectic = self.phase_table_local(GATES.phase, d, 0)
             diff_m = np.around(phase_table_unitary - phase_table_symplectic, 10)
             assert not np.any(diff_m), 'Symplectic phase table does not match unitary phase table for Phase gate'
 
-            G = SUM(0, 1, d)
-            phase_table_unitary, phase_table_symplectic = self.phase_table_entangling(G)
+            phase_table_unitary, phase_table_symplectic = self.phase_table_entangling(GATES.sum, 0, 1)
             diff_m = np.around(phase_table_unitary - phase_table_symplectic, 10)
-            assert not np.any(diff_m), 'Symplectic phase table does not match unitary phase table for SUM[0,1] gate'
+            assert not np.any(
+                diff_m), 'Symplectic phase table does not match unitary phase table for GATES.sum[0,1] gate'
 
-            G = SUM(1, 0, d)
-            phase_table_unitary, phase_table_symplectic = self.phase_table_entangling(G)
+            phase_table_unitary, phase_table_symplectic = self.phase_table_entangling(GATES.sum, 1, 0)
             diff_m = np.around(phase_table_unitary - phase_table_symplectic, 10)
-            assert not np.any(diff_m), 'Symplectic phase table does not match unitary phase table for SUM[1,0] gate'
+            assert not np.any(
+                diff_m), 'Symplectic phase table does not match unitary phase table for GATES.sum[1,0] gate'

--- a/tests/core_tests/find_symplectic_test.py
+++ b/tests/core_tests/find_symplectic_test.py
@@ -196,7 +196,7 @@ class TestSymplecticSolver:
             pl_sum = pl_sum[basis_indices]
 
             # scramble input hamiltonian to get target
-            C = Circuit.from_random(len(dimensions), 10 * n**2, dimensions=dimensions)
+            C = Circuit.from_random(len(dimensions), 10 * n**2)
             target_pl_sum = C.act(pl_sum)
             # target hamiltonian
             sym_sum = pl_sum.tableau()


### PR DESCRIPTION
## 📝 Description
Closes #56. 

- The idea of this refactoring is to make Gates singleton that are not modified. 
  - They are represented by their symplectic and phase vector. 
  - The phase vector can depend on the dimensions, so it is possible to instatiate gates with a set of phase vector, the correct one will be selected whenever the Gate acts.

- Circuits are instantiated with a list of gates and a corresponding list of quidit indices at which those gates are applied. 
  - [IDEA] Circuits can be optionally equipped with a dimensions array. If this is given, it is possible to get composite gate and unitary without specifying the dimensions.

We refactor Gate and Circuit:

- [x] Add interface for Gate
- [x] Remove dimensions and qudit indices from Gate
- [ ] Add interface for Circuit
- [x] Add list of qudit indices to Circuit.

## ✅ Checklist before requesting a review

- [ ] I have made corresponding changes to the documentation.
- [ ] The code follows the defined style guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] The code passes CI.