### PR TITLE
Some minor fixes for PauliObject

### DIFF
--- a/src/sympleq/core/paulis/pauli.py
+++ b/src/sympleq/core/paulis/pauli.py
@@ -69,7 +69,7 @@ class Pauli(PauliObject):
     @classmethod
     def from_string(cls, pauli_str: str, dimension: int = DEFAULT_QUDIT_DIMENSION) -> Pauli:
         """
-        Create a Pauli object from a string representation.
+        Create a Pauli from a string representation.
 
         Parameters
         ----------
@@ -179,7 +179,7 @@ class Pauli(PauliObject):
     @property
     def phases(self) -> np.ndarray:
         """
-        Returns the phases associated with the Pauli object.
+        Returns the phases associated with the Pauli.
         For a Pauli operator, this is just the trivial phase.
 
         Returns
@@ -192,7 +192,7 @@ class Pauli(PauliObject):
     @property
     def weights(self) -> np.ndarray:
         """
-        Returns the weights associated with the Pauli object.
+        Returns the weights associated with the Pauli.
         For a Pauli operator, this is just 1.
 
         Returns
@@ -279,6 +279,19 @@ class Pauli(PauliObject):
         new_tableau = (self.tableau + A.tableau) % self.lcm
 
         return Pauli(new_tableau, dimensions=self.dimensions)
+
+    def __repr__(self) -> str:
+        """
+        Return the string representation of the Pauli.
+        (in a format that is helpful for debugging).
+
+        Returns
+        -------
+        str
+            A string in the format "Pauli(x_exp=..., z_exp=..., dimensions=...)".
+        """
+
+        return f"PauliString(tableau={self.tableau}, dimensions={self.dimensions})"
 
     def __str__(self) -> str:
         """

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -224,9 +224,8 @@ class PauliObject(ABC):
         ----------
         other_pauli : Pauli object
             The Pauli object instance to compare against.
-
-        threshold: int
-
+        threshold: int, optional
+            The number of matching digits after the comma to consider two arrays as equal.
 
         Returns
         -------
@@ -471,11 +470,11 @@ class PauliObject(ABC):
 
         Examples
         --------
-        >>> ps = PauliString(x_exp, z_exp, dimensions)
+        >>> ps = PauliString.from_exponents(x_exp, z_exp, dimensions)
         >>> ps_squared = ps ** 2
         """
 
-        if self.n_paulis():
+        if self.n_paulis() > 1:
             raise Exception("A Pauli object with more than a PauliString cannot be exponentiated.")
 
         tableau = np.mod(self.tableau * A, np.tile(self.dimensions, 2))

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -16,44 +16,41 @@ class PauliObject(ABC):
                  weights: int | float | complex | list[int | float | complex] | np.ndarray | None = None,
                  phases: int | list[int] | np.ndarray | None = None):
         """
-        Constructor for Pauli objects represented in symplectic tableau form.
+        Initialize a PauliObject represented in symplectic tableau form.
+
         Represents a sum of Pauli operators acting on multiple qudits.
-        For more details, see the references:
-        `Phys. Rev. A 71, 042315 (2005) <https://doi.org/10.1103/PhysRevA.71.042315>`_
-        and
-        `Phys. Rev. A 70, 052328 (2004) <https://doi.org/10.1103/PhysRevA.70.052328>`_
+        See references:
+            - Phys. Rev. A 71, 042315 (2005)
+            - Phys. Rev. A 70, 052328 (2004)
 
         Parameters
         ----------
         tableau : np.ndarray
-            Symplectic tableau representation of the object. A 2-D array with shape (n_paulis, 2 * n_qudits).
-            For a single Pauli and a PauliString, n_paulis = 1.
+            Symplectic tableau representation of the object with shape
+            (n_paulis, 2 * n_qudits). The first half corresponds to X
+            exponents, and the second half to Z exponents.
         dimensions : int | list[int] | np.ndarray | None, optional
-            Qudit dimension(s).
-            - If int, a single qudit dimension is assumed or broadcast where appropriate.
-            - If list/np.ndarray, must match the number of qudits implied by `tableau`.
-            - If None, all dimensions are defaulted to DEFAULT_QUDIT_DIMENSION.
-        weights : list | np.ndarray | None, optional
-            Coefficients associated with each PauliString (for Pauli object).
-            If None, it defaults to 1.
-            For PauliString and Pauli, it is just a 1-D array of length 1.
-        phases : list[int] | np.ndarray | None, optional
-            Integer phases associated with each PauliString.
-            Values are typically interpreted modulo (2 * lcm()).
-            If None, it defaults to zero.
+            Qudit dimension(s). If int, all qudits share the same dimension.
+            If list or array, its length must equal the number of qudits.
+            Defaults to `DEFAULT_QUDIT_DIMENSION` if None.
+        weights : int | float | complex | list | np.ndarray | None, optional
+            Coefficients associated with each Pauli term. Defaults to 1.
+        phases : int | list[int] | np.ndarray | None, optional
+            Integer phase factors for each Pauli term, typically modulo
+            `2 * lcm(dimensions)`. Defaults to 0.
 
         Attributes
         ----------
-        weights: list[int | float | complex] | np.ndarray | None = None
-            The weights for each PauliString.
-        phases: int | list[int] | np.ndarray | None = None
-            The phases of the PauliStrings in the range [0, lcm(dimensions) - 1].
-        dimensions: list[int] | np.ndarray | int, optional
-            The dimensions of each qudit. If an integer is provided,
-            all qudits are assumed to have the same dimension.
-            If no value is provided, the default is `DEFAULT_QUDIT_DIMENSION`.
-        lcm: int
-            Least common multiplier of all qudit dimensions.
+        tableau : np.ndarray
+            Symplectic tableau representing the Pauli operators.
+        dimensions : np.ndarray
+            Dimensions of each qudit.
+        weights : np.ndarray
+            Coefficients (amplitudes) for each Pauli term.
+        phases : np.ndarray
+            Integer phases for each Pauli term.
+        lcm : int
+            Least common multiple of all qudit dimensions.
         """
 
         if tableau.ndim == 1:
@@ -93,101 +90,98 @@ class PauliObject(ABC):
     @property
     def tableau(self) -> np.ndarray:
         """
-        Returns the tableau representation of the Pauli object.
-        The tableau representation is a vector of length 2 * n_qudits,
-        where the first n_qudits entries correspond to the X exponents and the
-        last n_qudits entries correspond to the Z exponents of the Pauli string.
-        It is essential for efficient algebraic operations on Pauli strings, see
-        `Phys. Rev. A 70, 052328 (2004) <https://doi.org/10.1103/PhysRevA.70.052328>`_.
+        Return the symplectic tableau representation of the Pauli object.
+
+        The tableau is a 2D array of shape (n_paulis, 2 * n_qudits),
+        where the first half represents X exponents and the second half Z exponents.
 
         Returns
         -------
         np.ndarray
-            The tableau representation of the Pauli object.
+            Tableau representation of the Pauli object.
         """
         return self._tableau
 
     @property
     def dimensions(self) -> np.ndarray:
         """
-        Returns the dimensions of the Pauli object.
+        Return the dimensions of each qudit.
 
         Returns
         -------
         np.ndarray
-            A 1D numpy array of length n_qudits().
+            A 1D array of qudit dimensions of length `n_qudits`.
         """
         return self._dimensions
 
     @property
     def lcm(self) -> int:
         """
-        Returns the least common multiplier of the dimensions of the Pauli object.
+        Return the least common multiple (LCM) of all qudit dimensions.
 
         Returns
         -------
         int
-            The Pauli object dimensions least common multiplier as integer.
+            The least common multiple of the qudit dimensions.
         """
         return self._lcm
 
     def n_qudits(self) -> int:
         """
-        Returns the number of qudits represented by the Pauli object.
+        Return the number of qudits represented by the Pauli object.
 
         Returns
         -------
         int
-            The number of qudits.
+            Number of qudits.
         """
         return len(self.dimensions)
 
     def n_paulis(self) -> int:
         """
-        Returns the number of Pauli strings represented by the Pauli object.
+        Return the number of Pauli terms in the object.
 
         Returns
         -------
         int
-            The number of Pauli strings.
+            Number of Pauli operators (rows in the tableau).
         """
         return len(self.tableau)
 
     def shape(self) -> tuple[int, int]:
         """
-        Get the shape of the Pauli object.
+        Return the shape of the Pauli object.
 
         Returns
         -------
         tuple[int, int]
-            The number of Pauli operators and the number of qudits.
+            Tuple of (n_paulis, n_qudits).
         """
         return self.n_paulis(), self.n_qudits()
 
     @property
     @abstractmethod
     def phases(self) -> np.ndarray:
-        # FIXME: improve docstring
         """
-        Returns the phases associated with the Pauli object.
-        These phases represent the numerator, the denominator is 2 * self.lcm
+        Return the integer phases associated with the Pauli object.
+
+        Phases represent numerators, where denominators are `2 * self.lcm`.
 
         Returns
         -------
         np.ndarray
-            The phases as a 1d-vector.
+            1D array of integer phase values modulo `2 * lcm`.
         """
         pass
 
     def set_phases(self, new_phases: list[int] | np.ndarray):
-        # FIXME: improve docstring
         """
-        Set the phases associated with the Pauli object.
+        Set new integer phases for the Pauli object.
 
         Parameters
-        -------
-        new_phases: list[int] | np.ndarray
-            The new phases as a 1d-vector.
+        ----------
+        new_phases : list[int] | np.ndarray
+            1D array or list of new integer phase values.
         """
         pass
 
@@ -195,43 +189,42 @@ class PauliObject(ABC):
     @abstractmethod
     def weights(self) -> np.ndarray:
         """
-        Returns the weights associated with the Pauli object.
+        Return the weights (coefficients) of the Pauli terms.
 
         Returns
         -------
         np.ndarray
-            The weights as a 1d-vector.
+            1D array of scalar coefficients.
         """
         pass
 
     def set_weights(self, new_weights: list[int] | np.ndarray):
-        # FIXME: improve docstring
         """
-        Set the weights associated with the Pauli object.
+        Set new weights (coefficients) for the Pauli object.
 
         Parameters
-        -------
-        new_weights: list[int] | np.ndarray
-            The new weights as a 1d-vector.
+        ----------
+        new_weights : list[int] | np.ndarray
+            1D array or list of new scalar coefficients.
         """
         pass
 
     def is_close(self, other_pauli: Self, threshold: int = 10) -> bool:
         """
-        Determine if two Pauli object objects are (almost) equal.
+        Check whether two Pauli objects are approximately equal.
 
         Parameters
         ----------
-        other_pauli : Pauli object
-            The Pauli object instance to compare against.
-        threshold: int, optional
-            The number of matching digits after the comma to consider two arrays as equal.
+        other_pauli : PauliObject
+            Pauli object to compare against.
+        threshold : int, optional
+            Number of matching decimal digits required for equality. Default is 10.
 
         Returns
         -------
         bool
-            True if both Pauli object instances have identical PauliStrings, weights, phases, and dimensions;
-            False otherwise.
+            True if all tableau entries, weights, phases, and dimensions
+            match within tolerance; False otherwise.
         """
         if not isinstance(other_pauli, self.__class__):
             return False
@@ -251,14 +244,16 @@ class PauliObject(ABC):
         return True
 
     def hermitian_conjugate(self) -> Self:
-        # FIXME: add reference
         """
-        Returns the Hermitian conjugate of the Pauli object.
+        Return the Hermitian conjugate of the Pauli object.
+
+        The conjugate operation negates tableau exponents, conjugates weights,
+        and adjusts phases to preserve physical equivalence.
 
         Returns
         -------
         PauliObject
-            The PauliObject Hermitian conjugate
+            Hermitian conjugate of the Pauli object.
         """
         conjugate_weights = np.conj(self.weights)
         conjugate_tableau = (-self.tableau) % np.tile(self.dimensions, 2)
@@ -283,25 +278,24 @@ class PauliObject(ABC):
 
     def is_hermitian(self) -> bool:
         """
-        Checks if the PauliObject is Hermitian
+        Check if the Pauli object is Hermitian.
 
         Returns
         -------
         bool
-            True if the PauliObject is Hermitian, False otherwise
+            True if the object equals its Hermitian conjugate; False otherwise.
         """
         # NOTE: rounding errors could make this fail, hence we call the is_close function.
         return self.to_standard_form().is_close(self.H().to_standard_form())
 
     def _sanity_check(self):
         """
-        Validates the consistency of the Pauli object's internal representation.
+        Validate internal consistency of the Pauli object.
 
         Raises
         ------
         ValueError
-            If the lengths of `tableau`, and `dimensions` are not consistent
-            or if any exponent is not valid for its corresponding dimension.
+            If tableau, dimensions, or exponents are inconsistent or invalid.
         """
         if len(self.weights) != self.n_paulis():
             # FIXME: Improve error message
@@ -336,17 +330,17 @@ class PauliObject(ABC):
 
     def __eq__(self, other_pauli: Self) -> bool:
         """
-        Determine if two Pauli object objects are equal.
+        Determine if two Pauli objects are equal.
 
         Parameters
         ----------
-        other_pauli : Pauli object
-            The Pauli object instance to compare against.
+        other_pauli : PauliObject
+            Object to compare with.
 
         Returns
         -------
         bool
-            True if both Pauli object instances have identical PauliStrings, weights, phases, and dimensions;
+            True if tableau, weights, phases, and dimensions match exactly;
             False otherwise.
         """
         if not isinstance(other_pauli, self.__class__):
@@ -368,37 +362,46 @@ class PauliObject(ABC):
 
     def __ne__(self, other_pauli: PauliObject) -> bool:
         """
-        Determine if two Pauli object objects are different.
+        Determine if two Pauli objects are different.
 
         Parameters
         ----------
-        other_pauli : Pauli object
-            The Pauli object instance to compare against.
+        other_pauli : PauliObject
+            Object to compare with.
 
         Returns
         -------
         bool
-            True if the Pauli object instances do not have identical PauliStrings, weights, phases, and dimensions;
-            False otherwise.
+            True if objects are not equal; False otherwise.
         """
         return not self == other_pauli
 
     def __gt__(self, other_pauli: PauliObject) -> bool:
         """
-        Compare this PauliString with another PauliString for the greater-than relationship.
-        This method overrides the `>` operator to compare two PauliString objects by converting
-        them to their integer representations (with bits reversed) and checking if this instance
-        is greater than the other.
+        Strict greater-than comparison for ordering single Pauli terms.
+
+        Behavior
+        --------
+        This operator is intended to impose an ordering on single-term Pauli
+        objects by interpreting their tableau as an integer (or comparable)
+        representation. It is undefined for multi-term objects.
 
         Parameters
         ----------
-        other_pauli : PauliString
-            The other PauliString instance to compare against.
+        other_pauli : PauliObject
+            Other Pauli object to compare against. Both objects must represent
+            a single Pauli term and share identical `dimensions`.
 
         Returns
         -------
         bool
-            True if this PauliString is greater than `other_pauli`, False otherwise.
+            True if `self` is greater than `other_pauli` according to the
+            implemented integer-like ordering; False otherwise.
+
+        Raises
+        ------
+        ValueError
+            If either object contains multiple Pauli terms or if dimensions differ.
 
         Examples
         --------
@@ -430,20 +433,22 @@ class PauliObject(ABC):
 
     def __lt__(self, other_pauli: Self) -> bool:
         """
-        Compare this PauliString with another PauliString for the greater-than relationship.
-        This method overrides the `<` operator to compare two PauliString objects by converting
-        them to their integer representations (with bits reversed) and checking if this instance
-        is smaller than the other.
+        Strict less-than comparison for ordering single Pauli terms.
 
         Parameters
         ----------
-        other_pauli : PauliString
-            The other PauliString instance to compare against.
+        other_pauli : PauliObject
+            Other Pauli object to compare against. Both must represent single terms.
 
         Returns
         -------
         bool
-            True if this PauliString is smaller than `other_pauli`, False otherwise.
+            True if `self` is less than `other_pauli` according to the implemented ordering.
+
+        Raises
+        ------
+        ValueError
+            If preconditions (single-term objects, matching dimensions) are not met.
 
         Examples
         --------
@@ -456,17 +461,23 @@ class PauliObject(ABC):
 
     def __pow__(self, A: int) -> Self:
         """
-        Raises the Pauli object to the power of an integer exponent.
+        Integer power of a Pauli object.
 
         Parameters
         ----------
         A : int
-            The integer exponent to which the Pauli object is to be raised.
+            Exponent to raise the Pauli object to. Typically only defined for
+            single-term Pauli objects; behavior for sums depends on implementation.
 
         Returns
         -------
-        Pauli object
-            A new Pauli object instance representing the result of the exponentiation.
+        Self
+            Resulting PauliObject after exponentiation.
+
+        Raises
+        ------
+        ValueError
+            If exponentiation is undefined for the current object (e.g., multi-term).
 
         Examples
         --------
@@ -540,7 +551,10 @@ class PauliObject(ABC):
 
     def to_standard_form(self) -> Self:
         """
-        Get the Pauli object in standard form.
+        Produce a standardized form of the Pauli object.
+
+        The standard form consolidates equivalent Pauli terms, normalizes phases,
+        and ensures a canonical ordering of terms.
 
         Returns
         -------
@@ -553,8 +567,10 @@ class PauliObject(ABC):
 
     def standardise(self):
         """
-        Standardises the Pauli object object by combining equivalent Paulis and
-        adding phase factors to the weights then resetting the phases.
+        In-place standardisation of the Pauli object.
+
+        Combines equivalent terms, absorbs phases into weights where appropriate,
+        and normalizes the internal representation for deterministic comparisons.
         """
         self.phase_to_weight()
         T = self.tableau
@@ -571,6 +587,12 @@ class PauliObject(ABC):
     def to_hilbert_space(self, pauli_string_index: int | None = None) -> np.ndarray:
         """
         Get the matrix form of the PauliObject as a sparse matrix.
+
+        Parameters
+        ----------
+        pauli_string_index : int | None, optional
+            Index of a specific Pauli term to convert. If None, the full operator
+            (sum of all terms) is returned.
 
         Returns
         -------

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
+import functools
 import numpy as np
 from typing import TypeVar, Self, Union
 
@@ -11,6 +12,7 @@ ScalarType = Union[float, complex, int]
 PauliOrScalarType = Union['PauliObject', ScalarType]
 
 
+@functools.total_ordering
 class PauliObject(ABC):
     def __init__(self, tableau: np.ndarray, dimensions: int | list[int] | np.ndarray | None = None,
                  weights: int | float | complex | list[int | float | complex] | np.ndarray | None = None,

--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import overload, TYPE_CHECKING
 import numpy as np
-import functools
 import re
 import scipy.sparse as sp
 
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
     from .pauli_sum import PauliSum
 
 
-@functools.total_ordering
 class PauliString(PauliObject):
     @classmethod
     def from_exponents(cls, x_exp: list[int] | np.ndarray | str | int, z_exp: list[int] | np.ndarray | int,

--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -154,12 +154,11 @@ class PauliString(PauliObject):
         ----------
         n_qudits : int
             The number of qudits in the Pauli string.
-        dimensions : list[int] or np.ndarray
+        dimensions : int | list[int] | np.ndarray
             The dimensions of each qudit. Should be a list or array of integers specifying the dimension for each qudit.
+            The size of dimensions determines the number of qudits.
         seed : int or None, optional
             Seed for the random number generator to ensure reproducibility. Default is None.
-        sanity_check : bool = True
-            Whether to run sanity checks for the input, the default is True.
 
         Returns
         -------
@@ -168,6 +167,9 @@ class PauliString(PauliObject):
         """
         if seed is not None:
             np.random.seed(seed)
+
+        if isinstance(dimensions, int):
+            dimensions = [dimensions]
 
         tableau = np.concatenate([np.random.randint(dimensions, dtype=int), np.random.randint(dimensions, dtype=int)])
         return cls(tableau, dimensions)

--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -17,7 +17,33 @@ class PauliString(PauliObject):
     @classmethod
     def from_exponents(cls, x_exp: list[int] | np.ndarray | str | int, z_exp: list[int] | np.ndarray | int,
                        dimensions: list[int] | np.ndarray | int | None = None) -> PauliString:
+        """
+        Create a PauliString instance from X and Z exponents.
 
+        Parameters
+        ----------
+        x_exp : list[int] | np.ndarray | str | int
+            The X exponents used to create the PauliString tableau.
+            If no Z exponents are given, the X exponents can be also given as a parseable string.
+            If an integer is provided, it is assumed the PauliString contains a single Pauli.
+        z_exp: list[int] | np.ndarray | int
+            The Z exponents used to create the PauliString tableau.
+            If an integer is provided, it is assumed the PauliString contains a single Pauli.
+        dimensions: list[int] | np.ndarray | int, optional
+            The dimensions of each qudit. If an integer is provided,
+            all qudits are assumed to have the same dimension.
+            If no value is provided, the default is `DEFAULT_QUDIT_DIMENSION`.
+
+        Returns
+        -------
+        PauliString
+            A PauliString instance representing the given exponents.
+
+        Raises
+        ------
+        ValueError
+            If x_exp, z_exp, and dimensions don't have the same length.
+        """
         if isinstance(x_exp, str):
             if z_exp is not None:
                 raise Warning('If input string is provided, z_exp is unnecessary')
@@ -61,12 +87,12 @@ class PauliString(PauliObject):
     @classmethod
     def from_pauli(cls, pauli: Pauli) -> PauliString:
         """
-        Create a PauliString instance from a single Pauli object.
+        Create a PauliString instance from a single Pauli.
 
         Parameters
         ----------
         pauli : Pauli
-            The Pauli object to convert into a PauliString.
+            The Pauli to convert into a PauliString.
 
         Returns
         -------
@@ -174,26 +200,26 @@ class PauliString(PauliObject):
 
     def __repr__(self) -> str:
         """
-        Return the string representation of the Pauli object
+        Return the string representation of the PauliString.
         (in a format that is helpful for debugging).
 
         Returns
         -------
         str
-            A string in the format "Pauli(x_exp=..., z_exp=..., dimensions=...)".
+            A string in the format "PauliString(tableau=..., dimensions=...)".
         """
 
-        return f"PauliString(x_exp={self.x_exp}, z_exp={self.z_exp}, dimensions={self.dimensions})"
+        return f"PauliString(tableau={self.tableau}, dimensions={self.dimensions})"
 
     def __str__(self) -> str:
         """
-        Return the string representation of the Pauli object
+        Return the string representation of the PauliString.
         (in the format also employed for constructing an instance of the class).
 
         Returns
         -------
         str
-            The string representation of the Pauli object, with each qudit's
+            The string representation of the PauliString, with each qudit's
             exponents shown as 'x{exp}z{exp} x{exp}z{exp} x{exp}z{exp} ...'.
         """
 
@@ -251,7 +277,7 @@ class PauliString(PauliObject):
         Parameters
         ----------
         A : Pauli
-            The Pauli object to be right-multiplied with this PauliString.
+            The Pauli to be right-multiplied with this PauliString.
 
         Returns
         -------
@@ -335,8 +361,7 @@ class PauliString(PauliObject):
     @property
     def phases(self) -> np.ndarray:
         """
-        Returns the phases associated with the Pauli object.
-        For a Pauli operator, this is just the trivial phase.
+        Returns the phases associated with the PauliString.
 
         Returns
         -------
@@ -348,8 +373,7 @@ class PauliString(PauliObject):
     @property
     def weights(self) -> np.ndarray:
         """
-        Returns the weights associated with the Pauli object.
-        For a Pauli operator, this is just 1.
+        Returns the weights associated with the Pauli String.
 
         Returns
         -------
@@ -359,6 +383,14 @@ class PauliString(PauliObject):
         return np.asarray([1], dtype=complex)
 
     def as_pauli_sum(self) -> PauliSum:
+        """
+        Converts the PauliString to the embedding PauliSum.
+
+        Returns
+        -------
+        PauliSum
+            The PauliSum containing the PauliString as single entry.
+        """
         return PauliSum(self.tableau, self.dimensions, self.weights, self.phases)
 
     def n_identities(self) -> int:
@@ -374,7 +406,7 @@ class PauliString(PauliObject):
 
     def get_pauli(self, index: int) -> Pauli:
         """
-        Returns a Pauli object at the input index.
+        Returns a Pauli at the input index.
 
         Parameters
         ----------
@@ -384,7 +416,7 @@ class PauliString(PauliObject):
         Returns
         -------
         Pauli
-            A Pauli object.
+            The Pauli at the given index.
         """
 
         tableau = np.asarray([self.x_exp[index], self.z_exp[index]], dtype=int)
@@ -392,12 +424,12 @@ class PauliString(PauliObject):
 
     def get_paulis(self) -> list[Pauli]:
         """
-        Returns a list of Pauli objects corresponding to the PauliString tableau.
+        Returns a list of Paulis corresponding to the PauliString tableau.
 
         Returns
         -------
         list[Pauli]
-            A list of Pauli objects.
+            A list of Pauli.
         """
         return [self.get_pauli(i) for i in range(self.n_qudits())]
 

--- a/src/sympleq/core/paulis/pauli_sum.py
+++ b/src/sympleq/core/paulis/pauli_sum.py
@@ -49,12 +49,12 @@ class PauliSum(PauliObject):
     @classmethod
     def from_pauli(cls, pauli: Pauli) -> 'PauliSum':
         """
-        Create a PauliSum instance from a single Pauli object.
+        Create a PauliSum instance from a single Pauli.
 
         Parameters
         ----------
         pauli : Pauli
-            The Pauli object to convert into a PauliSum.
+            The Pauli to convert into a PauliSum.
 
         Returns
         -------
@@ -194,12 +194,12 @@ class PauliSum(PauliObject):
 
         Parameters
         ----------
-        n_pauli : int
+        n_paulis : int
             The number of Pauli operators to include in the sum.
         n_qudits : int
             The number of qudits in each Pauli operator.
-        dimensions : list[int] | np.ndarray
-            The dimensions of the qudits.
+        dimensions : int | list[int] | np.ndarray
+            The dimensions of the qudits. The size of dimensions determines the number of qudits.
         rand_weights : bool
             Whether to use random weights for the Pauli operators.
 
@@ -215,6 +215,11 @@ class PauliSum(PauliObject):
         weights = 2 * (np.random.rand(n_paulis) - 0.5) if rand_weights else np.ones(n_paulis)
         string_seeds = np.random.randint(1000000, size=1000)
         # Ensure no duplicate strings
+        # FIXME: this check is useful, but it fails if the product is too large and does not fit in int64.
+        # if n_paulis > 2 * int(np.prod(dimensions)):
+        #     raise ValueError(
+        #         f"Too many Paulis {n_paulis} for dimensions {dimensions} to guarantee unicity\
+        #              (max {2 * int(np.prod(dimensions))}).")
         strings = []
         for i in range(n_paulis):
             ps = PauliString.from_random(dimensions, seed=string_seeds[i])
@@ -229,7 +234,7 @@ class PauliSum(PauliObject):
     @property
     def phases(self) -> np.ndarray:
         """
-        Returns the phases associated with the Pauli-like object.
+        Returns the phases associated with the PauliSum.
         These phases represent the numerator, the denominator is 2 * self.lcm
 
         Returns
@@ -252,7 +257,7 @@ class PauliSum(PauliObject):
     @property
     def weights(self) -> np.ndarray:
         """
-        Returns the weights associated with the Pauli-like object.
+        Returns the weights associated with the PauliSum.
 
         Returns
         -------
@@ -565,35 +570,38 @@ class PauliSum(PauliObject):
 
     def __mul__(self, A: PauliOrScalarType) -> PauliSum:
         """
-        Multiply a Pauli object and a PauliObject (or scalar) objects element-wise.
+        Multiply a PauliSum and a PauliObject or scalar objects element-wise.
         It corresponds to operator multiplication (`*`).
         It adds the tableaus of the two PauliSums modulo their dimensions.
 
         Parameters
         ----------
-        A : PauliObject Pauli | PauliString | Pauli object | float | int
+        A : PauliObject | float | int | complex
             The PauliObject or scalar instance to be multiplied with `self`.
 
         Returns
         -------
-        Pauli object
-            A new Pauli object instance representing the product of `self` and `A`.
+        PauliSum
+            A new PauliSum instance representing the product of `self` and `A`.
 
         Raises
         ------
         ValueError
-            If `A` is not an instance of a Pauli, Pauli object, PauliString, or scalar.
+            If `A` is not an instance of a Pauli, PauliSum, PauliString, or scalar.
 
         Examples
         --------
-        >>> ps1 = Pauli object.from_pauli_strings("x1z0 x0z1", [3, 2])
-        >>> ps2 = Pauli object.from_pauli_strings("x2z1 x0z0", [3, 2])
+        >>> ps1 = PauliSum.from_pauli_strings("x1z0 x0z1", [3, 2])
+        >>> ps2 = PauliSum.from_pauli_strings("x2z1 x0z0", [3, 2])
         >>> ps3 = ps1 * ps2
-        Pauli object(...)
+        PauliSum(...)
         """
 
         if isinstance(A, ScalarType):
             return PauliSum(self.tableau, self.dimensions, self.weights * A, self.phases)
+
+        if isinstance(A, Pauli):
+            return self * PauliSum.from_pauli(A)
 
         if isinstance(A, PauliString):
             return self * PauliSum.from_pauli_strings(A)
@@ -653,16 +661,16 @@ class PauliSum(PauliObject):
 
         Examples
         --------
-        >>> ps1 = Pauli object.from_pauli_strings("x1z0 x0z1", [3, 2])
-        >>> ps2 = Pauli object.from_pauli_strings("x2z1 x0z0", [3, 2])
+        >>> ps1 = PauliSum.from_pauli_strings("x1z0 x0z1", [3, 2])
+        >>> ps2 = PauliSum.from_pauli_strings("x2z1 x0z0", [3, 2])
         >>> ps3 = ps1 * ps2
-        Pauli object(...)
+        PauliSum(...)
         """
         return self * A
 
     def __truediv__(self, A: ScalarType) -> PauliSum:
         """
-        Divide a Pauli object by a scalar. It corresponds to operator division (`/`).
+        Divide a PauliSum by a scalar. It corresponds to operator division (`/`).
 
         Parameters
         ----------
@@ -671,8 +679,8 @@ class PauliSum(PauliObject):
 
         Returns
         -------
-        Pauli object
-            A new Pauli object instance representing the quotient of `self` and `A`.
+        PauliSum
+            A new PauliSum instance representing the quotient of `self` and `A`.
 
         Raises
         ------

--- a/tests/core_tests/cirucits_tests/gates_test.py
+++ b/tests/core_tests/cirucits_tests/gates_test.py
@@ -310,7 +310,7 @@ class TestGates():
             for d in primes:
                 for i in range(num_tests):
                     if n < 6 and d == 2:
-                        index = random.randint(0, symplectic_group_size(n))
+                        index = random.randint(0, symplectic_group_size(n) - 1)
                         F = symplectic_gf2(index, n)
                     else:
                         F = symplectic_random_transvection(n, dimension=d)

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -21,9 +21,9 @@ class TestPaulis:
             id = Pauli.Idnd(dim)
 
             assert x1 * z1 == y1, 'Error in Pauli multiplication (x * z = y) ' + (x1 * z1).__str__()
-            #assert x1**dim == id, 'Error in Pauli exponentiation (x**dim = id) ' + (x1**dim).__str__()
-            #assert y1**dim == id, 'Error in Pauli exponentiation (y**dim = id) ' + (y1**dim).__str__()
-            #assert z1**dim == id, 'Error in Pauli exponentiation (z**dim = id)  ' + (z1**dim).__str__()
+            assert x1**dim == id, 'Error in Pauli exponentiation (x**dim = id) ' + (x1**dim).__str__()
+            assert y1**dim == id, 'Error in Pauli exponentiation (y**dim = id) ' + (y1**dim).__str__()
+            assert z1**dim == id, 'Error in Pauli exponentiation (z**dim = id)  ' + (z1**dim).__str__()
             assert x1 * y1 == z1, 'Error in Pauli multiplication (x * y = z) ' + (x1 * y1).__str__()
             assert y1 * z1 == x1, 'Error in Pauli multiplication (y * z = x) ' + (y1 * z1).__str__()
             assert z1 * x1 == y1, 'Error in Pauli multiplication (z * x = y) ' + (z1 * x1).__str__()
@@ -446,15 +446,6 @@ class TestPaulis:
         assert P1.H() == P2
 
     def test_pauli_sum_is_hermitian(self):
-        def all_exponent_lists(dimensions):
-            """
-            Return a 2D NumPy array of all exponent lists x_exp
-            such that 0 <= x_i < d_i for each dimension d_i.
-            """
-            grids = np.meshgrid(*[np.arange(d) for d in dimensions], indexing="ij")
-            combos = np.stack(grids, axis=-1).reshape(-1, len(dimensions))
-            return combos
-
         for run in range(40):
             # Generate random dimensions array {d_1, d_2, d_3,...} such that \prod_i d_i <= 10
             dimensions = []
@@ -478,28 +469,8 @@ class TestPaulis:
                 H_e = H_e + 0.15 * (np.random.rand(D, D) + 1j * np.random.rand(D, D))
                 assert not np.array_equal(H_e, H_e.conjugate().transpose())
 
-            # Iterable: all_pauli_strings = all possible PauliStrings with given dimensions
-            x_exps = all_exponent_lists(dimensions)
-            z_exps = all_exponent_lists(dimensions)
-            all_pauli_strings = [PauliString.from_exponents(x_exp, z_exp, dimensions)
-                                 for x_exp in x_exps for z_exp in z_exps]
-            assert len(all_pauli_strings) == D**2
-
-            # Decompose H_e into PauliStrings
-            coefficients = []
-            selected_pauli_strings = []
+            pauli_sum = PauliSum.from_hilbert_space(H_e, dimensions)
             tolerance = 10**(-12)
-            for ps in all_pauli_strings:
-                ps_mat = PauliSum.from_pauli_strings(ps).to_hilbert_space()
-                ps_mat_ct = ps_mat.conjugate().transpose()
-                c_i = np.trace(ps_mat_ct @ H_e) / D
-                if abs(c_i) < tolerance:
-                    continue
-
-                coefficients.append(c_i)
-                selected_pauli_strings.append(ps)
-
-            pauli_sum = PauliSum.from_pauli_strings(selected_pauli_strings, weights=coefficients)
             assert np.max(np.abs((pauli_sum.to_hilbert_space().toarray() - H_e))) < tolerance
             assert pauli_sum.is_hermitian() == np.array_equal(H_e, H_e.conjugate().transpose())
 


### PR DESCRIPTION
## 📝 Description
Fix minor bugs

- [x] Add `from_hilbert_space` factory for PauliSum: https://github.com/QuAOS-Lab/SympleQ/pull/67/commits/89e79b17888b70780c5482cca26e355f4299b4c2
- [x] Off-by-one in `test_random_symplectic` https://github.com/QuAOS-Lab/SympleQ/pull/67/commits/a6092598d876121278f831c113b1b6228952ce62
- [x] Missing comparison in `PauliObject.__pow__` https://github.com/QuAOS-Lab/SympleQ/pull/67/commits/782b70adcaecb4f3503097cac3ebc5c74b328061
- [x] Move total ordering to PauliObject https://github.com/QuAOS-Lab/SympleQ/pull/67/commits/af781059513cb671ec5f5464af633d3def15cd82
- [ ] Fix docstrings

## ✅ Checklist before requesting a review

- [ ] I have made corresponding changes to the documentation.
- [x] The code follows the defined style guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] The code passes CI.