### PR TITLE
Add unit tests and fix phase weight handling

### DIFF
--- a/src/sympleq/core/paulis/pauli.py
+++ b/src/sympleq/core/paulis/pauli.py
@@ -224,7 +224,9 @@ class Pauli(PauliObject):
         PauliSum
             A PauliSum instance representing the given Pauli operator.
         """
-        return PauliSum(self.tableau, self.dimensions, self.weights, self.phases)
+        # FIXME: import at the top. Currently we can't because of circular imports.
+        from .pauli_sum import PauliSum
+        return PauliSum(self._tableau, self._dimensions, self._weights, self._phases)
 
     def as_pauli_string(self) -> PauliString:
         """
@@ -235,7 +237,9 @@ class Pauli(PauliObject):
         PauliString
             A PauliString instance representing the given Pauli operator.
         """
-        return PauliString(self.tableau, self.dimensions, self.weights, self.phases)
+        # FIXME: import at the top. Currently we can't because of circular imports.
+        from .pauli_string import PauliString
+        return PauliString(self._tableau, self._dimensions, self._weights, self._phases)
 
     def to_hilbert_space(self) -> sp.csr_matrix:
         """

--- a/src/sympleq/core/paulis/pauli.py
+++ b/src/sympleq/core/paulis/pauli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import numpy as np
 import scipy.sparse as sp
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -91,11 +92,11 @@ class Pauli(PauliObject):
             If the string cannot be parsed into two integer exponents.
         """
         tableau = np.empty(2, dtype=int)
-        try:
-            tableau[0] = int(pauli_str[1])
-            tableau[1] = int(pauli_str[3])
-        except Exception as e:
-            raise ValueError(f"Could not format tableau from input string: {e}.")
+        xz_exponents = re.split('x|z', pauli_str)[1:]
+        x_exp = int(xz_exponents[0])
+        z_exp = int(xz_exponents[1])
+        tableau[0] = x_exp
+        tableau[1] = z_exp
 
         P = cls(tableau, dimensions=dimension)
         P._sanity_check()

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -534,8 +534,7 @@ class PauliObject(ABC):
         Pauli object
             A copy of the Pauli object.
         """
-        return self.__class__(self.tableau.copy(), self.dimensions.copy(),
-                              self.weights.copy(), self.phases.copy())
+        return self.__class__(self._tableau.copy(), self._dimensions.copy(), self._weights.copy(), self._phases.copy())
 
     def phase_to_weight(self):
         """

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -187,6 +187,9 @@ class PauliObject(ABC):
         """
         pass
 
+    def reset_phases(self):
+        self._phases = np.zeros(len(self._phases))
+
     @property
     @abstractmethod
     def weights(self) -> np.ndarray:
@@ -270,7 +273,7 @@ class PauliObject(ABC):
             acquired_phases.append(2 * hermitian_conjugate_phase)
         acquired_phases = np.asarray(acquired_phases, dtype=int)
 
-        conjugate_initial_phases = (-self.phases) % (2 * self.lcm)
+        conjugate_initial_phases = (-self._phases) % (2 * self.lcm)
         conjugate_phases = (conjugate_initial_phases + acquired_phases) % (2 * self.lcm)
 
         return self.__class__(tableau=conjugate_tableau, dimensions=self.dimensions,
@@ -491,7 +494,7 @@ class PauliObject(ABC):
             raise Exception("A Pauli object with more than a PauliString cannot be exponentiated.")
 
         tableau = np.mod(self.tableau * A, np.tile(self.dimensions, 2))
-        return self.__class__(tableau, self.dimensions.copy(), self.weights.copy(), self.phases.copy())
+        return self.__class__(tableau, self._dimensions.copy(), self._weights.copy(), self._phases.copy())
 
     def __hash__(self) -> int:
         """
@@ -544,7 +547,7 @@ class PauliObject(ABC):
         """
         new_weights = np.zeros(self.n_paulis(), dtype=np.complex128)
         for i in range(self.n_paulis()):
-            phase = self.phases[i]
+            phase = self._phases[i]
             omega = np.exp(2 * np.pi * 1j * phase / (2 * self.lcm))
             new_weights[i] = self.weights[i] * omega
         self._phases = np.zeros(self.n_paulis(), dtype=int)

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -414,7 +414,7 @@ class PauliObject(ABC):
         """
 
         if self.n_paulis() > 1:
-            raise Exception("A Pauli object with more than a PauliString cannot be ordered.")
+            raise Exception("A Pauli object with more than one PauliString cannot be ordered.")
 
         if np.array_equal(self.dimensions, other_pauli.dimensions):
             raise Exception("Cannot compare PauliStrings with different dimensions.")

--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -410,7 +410,9 @@ class PauliString(PauliObject):
         PauliSum
             The PauliSum containing the PauliString as single entry.
         """
-        return PauliSum(self.tableau, self.dimensions, self.weights, self.phases)
+        # FIXME: import at the top. Currently we can't because of circular imports.
+        from .pauli_sum import PauliSum
+        return PauliSum(self._tableau, self._dimensions, self._weights, self._phases)
 
     def n_identities(self) -> int:
         """
@@ -683,7 +685,7 @@ class PauliString(PauliObject):
         if isinstance(key, np.ndarray):
             tableau_mask = np.concatenate([key, key + self.n_qudits()])
             return PauliString(
-                self.tableau[tableau_mask], self.dimensions[key])
+                self.tableau[tableau_mask], self.dimensions[key], self._weights, self._phases)
 
         raise ValueError(f"Cannot get item with key {key}. Key must be aof type int, slice, np.ndarray, or list[int].")
 

--- a/src/sympleq/core/paulis/pauli_sum.py
+++ b/src/sympleq/core/paulis/pauli_sum.py
@@ -189,6 +189,7 @@ class PauliSum(PauliObject):
                     n_paulis: int,
                     dimensions: int | list[int] | np.ndarray,
                     rand_weights: bool = True,
+                    rand_phases: bool = False,
                     seed: int | None = None) -> 'PauliSum':
         """
         Create a random PauliSum object.
@@ -203,6 +204,8 @@ class PauliSum(PauliObject):
             The dimensions of the qudits. The size of dimensions determines the number of qudits.
         rand_weights : bool
             Whether to use random weights for the Pauli operators.
+        rand_phases : bool
+            Whether to use random phases for the Pauli operators.
 
         Returns
         -------
@@ -229,8 +232,12 @@ class PauliSum(PauliObject):
                 j += 1
                 ps = PauliString.from_random(dimensions, seed=string_seeds[j])
             strings.append(ps)
+        # Generate random phases if required
+        # TODO: check random phases below are correctly generated
+        phases = 2 * np.random.randint(0, 2 * int(np.prod(dimensions)) - 1,
+                                       size=n_paulis) if rand_phases else [0] * n_paulis
 
-        return cls.from_pauli_strings(strings, weights=weights, phases=[0] * n_paulis).to_standard_form()
+        return cls.from_pauli_strings(strings, weights=weights, phases=phases).to_standard_form()
 
     @property
     def phases(self) -> np.ndarray:
@@ -1191,7 +1198,8 @@ class PauliSum(PauliObject):
         scipy.sparse.csr_matrix
             Matrix representation of input Pauli.
         """
-        # TODO: If pauli_string_index is selected it maybe should account for the weights and phases
+        # TODO: If pauli_string_index is selected it maybe should include phase and weight?
+        #       Luca -> Seems to me it already does? Which is totally fine :)
         if pauli_string_index is not None:
             ps = PauliSum(self.tableau[pauli_string_index], self.dimensions, self.weights, self.phases)
             return ps.to_hilbert_space()

--- a/src/sympleq/core/paulis/pauli_sum.py
+++ b/src/sympleq/core/paulis/pauli_sum.py
@@ -237,7 +237,7 @@ class PauliSum(PauliObject):
         phases = 2 * np.random.randint(0, 2 * int(np.prod(dimensions)) - 1,
                                        size=n_paulis) if rand_phases else [0] * n_paulis
 
-        return cls.from_pauli_strings(strings, weights=weights, phases=phases).to_standard_form()
+        return cls.from_pauli_strings(strings, weights=weights, phases=phases)
 
     @property
     def phases(self) -> np.ndarray:
@@ -399,7 +399,7 @@ class PauliSum(PauliObject):
         if isinstance(key, int):
             # Here we don't copy and return a view.
             tableau = self.tableau[key]
-            return PauliString(tableau, self.dimensions)
+            return PauliString(tableau, self.dimensions, self.weights[key], self.phases[key])
 
         if isinstance(key, (list, np.ndarray, slice)):
             return PauliSum(self.tableau[key], self.dimensions, self.weights[key], self.phases[key])
@@ -421,7 +421,7 @@ class PauliSum(PauliObject):
                 if isinstance(qudit_indices, (list, np.ndarray, slice)):
                     sub_tableau = self.tableau[pauli_indices, :][qudit_indices]
                     sub_dims = self.dimensions[qudit_indices]
-                    return PauliString(sub_tableau, sub_dims)
+                    return PauliString(sub_tableau, sub_dims, self.weights[key], self.phases[key])
 
             return self.get_subspace(qudit_indices, pauli_indices)
 

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -31,13 +31,13 @@ class TestPaulis:
             assert y1 * id == y1, 'Error in Pauli multiplication (y * id = y) ' + (y1 * id).__str__()
             assert z1 * id == z1, 'Error in Pauli multiplication (z * id = z) ' + (z1 * id).__str__()
 
-        for dim in [3, 5, 11]:
+        for dim in [3, 5, 7, 11, 13, 17]:
             for i in range(100):
-                s = np.random.randint(0, dim)
-                r = np.random.randint(0, dim)
+                s1 = np.random.randint(0, dim)
+                r1 = np.random.randint(0, dim)
                 s2 = np.random.randint(0, dim)
                 r2 = np.random.randint(0, dim)
-                p1 = Pauli.from_exponents(r, s, dim)
+                p1 = Pauli.from_exponents(r1, s1, dim)
                 p2 = Pauli.from_exponents(r2, s2, dim)
                 p3 = p1 * p2
                 assert p3.x_exp == (p1.x_exp + p2.x_exp) % dim, 'Error in Pauli multiplication (x_exp)'
@@ -45,21 +45,21 @@ class TestPaulis:
                 assert p3.dimension == dim, 'Error in Pauli multiplication (dimension)'
 
     def test_pauli_string_multiplication(self):
-        for dim in [2, 3, 5, 11]:
+        for dim in [2, 3, 5, 7, 11, 13, 15, 17]:
             for i in range(100):
-                r1 = np.random.randint(0, dim)
-                r2 = np.random.randint(0, dim)
-                s1 = np.random.randint(0, dim)
-                s2 = np.random.randint(0, dim)
-
+                r11 = np.random.randint(0, dim)
                 r12 = np.random.randint(0, dim)
-                r22 = np.random.randint(0, dim)
+                s11 = np.random.randint(0, dim)
                 s12 = np.random.randint(0, dim)
+
+                r21 = np.random.randint(0, dim)
+                r22 = np.random.randint(0, dim)
+                s21 = np.random.randint(0, dim)
                 s22 = np.random.randint(0, dim)
 
-                input_str1 = f"x{r1}z{s1} x{r2}z{s2}"
-                input_str2 = f"x{r12}z{s12} x{r22}z{s22}"
-                output_str_correct = f"x{(r1 + r12) % dim}z{(s1 + s12) % dim} x{(r2 + r22) % dim}z{(s2 + s22) % dim}"
+                input_str1 = f"x{r11}z{s11} x{r12}z{s12}"
+                input_str2 = f"x{r21}z{s21} x{r22}z{s22}"
+                output_str_correct = f"x{(r11 + r21) % dim}z{(s11 + s21) % dim} x{(r12 + r22) % dim}z{(s12 + s22) % dim}"
                 input_ps1 = PauliString.from_string(input_str1, dimensions=[dim, dim])
                 input_ps2 = PauliString.from_string(input_str2, dimensions=[dim, dim])
                 output_ps = input_ps1 * input_ps2
@@ -67,7 +67,7 @@ class TestPaulis:
                                                             dim, dim]), 'Error in PauliString multiplication'
 
     def test_pauli_string_tensor_product(self):
-        for dimensions in [2, 3, 5, 11]:
+        for dimensions in [2, 3, 5, 7, 11]:
             for i in range(100):
                 r1 = np.random.randint(0, dimensions)
                 r2 = np.random.randint(0, dimensions)
@@ -90,7 +90,7 @@ class TestPaulis:
                     output_str_correct, dimensions), 'Error in PauliString tensor product'
 
     def test_pauli_string_indexing(self):
-        for dim in [2, 3, 5]:
+        for dim in [2, 3, 5, 7]:
             for _ in range(100):
                 p_string1, r1, r2, s1, s2 = self.random_pauli_string(dim)
                 ps0 = Pauli.from_string(f"x{r1}z{s1}", dimension=dim)

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -487,7 +487,7 @@ class TestPaulis:
                 assert not np.array_equal(H_e, H_e.conjugate().transpose())
 
             pauli_sum = PauliSum.from_hilbert_space(H_e, dimensions)
-            tolerance = 10**(-12)
+            tolerance = 1e-12
             assert np.max(np.abs((pauli_sum.to_hilbert_space().toarray() - H_e))) < tolerance
             assert pauli_sum.is_hermitian() == np.array_equal(H_e, H_e.conjugate().transpose())
 
@@ -636,7 +636,7 @@ class TestPaulis:
                 dimensions = [random.choice(dimensions_to_choose_from)]
             # generate random PauliSum
             P = PauliSum.from_random(n_paulis, dimensions, rand_phases=True)
-            L = P.lcm()
+            L = P.lcm
             # check commutation relations pairwise
             for i in range(n_paulis):
                 for j in range(i + 1, n_paulis):
@@ -706,10 +706,10 @@ class TestPaulis:
             P = PauliSum.from_random(n_paulis, dimensions, rand_phases=False)
             n_terms = P.n_paulis()
 
-            weights = np.array(P.weights(), copy=True)
-            phases = np.array(P.phases(), copy=True)
+            weights = np.array(P.weights, copy=True)
+            phases = np.array(P.phases, copy=True)
 
-            L = P.lcm()
+            L = P.lcm
 
             # random integer shifts: add up to 2*L - 1
             phase_shifts = np.random.randint(0, 2 * L - 1, size=n_terms)
@@ -720,15 +720,15 @@ class TestPaulis:
             new_weights = (weights * np.exp(-2j * np.pi * phase_shifts / (2 * L))).tolist()
 
             # construct new PauliSum
-            P_dephased = PauliSum.from_tableau(P.tableau(), weights=new_weights,
-                                               phases=new_phases, dimensions=P.dimensions())
+            P_dephased = PauliSum.from_tableau(P.tableau, weights=new_weights,
+                                               phases=new_phases, dimensions=P.dimensions)
 
             # remove phases with "phase_to_weight"
             P_rephased = P_dephased.copy()
             P_rephased.phase_to_weight()
 
             # check that the weights of P_rephased match those of P
-            assert np.allclose(P_rephased.weights(), P.weights(), atol=1e-12), "Weights differ after phase_to_weight"
+            assert np.allclose(P_rephased.weights, P.weights, atol=1e-12), "Weights differ after phase_to_weight"
 
             # check that all PauliSums are the same:
             P.standardise()

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -193,13 +193,12 @@ class TestPaulis:
             x1 = Pauli.from_string(f'x{x_exp}z0', dimension=d)
             z1 = Pauli.from_string(f'x0z{z_exp}', dimension=d)
             y1 = Pauli.from_string(f'x{x_exp}z{z_exp}', dimension=d)
-            id = Pauli.from_string('x0z0', dimension=d)
+            id = Pauli.Idnd(dimension=d)
 
             assert x1 * z1 == y1, f'Error in Pauli multiplication for d={d}'
-            assert x1**(d - x_exp) == id, f'Error in Pauli exponentiation (x**{d} = id) for d={d}'
-            assert y1 * z1**(d - z_exp) * \
-                x1**(d - x_exp) == id, f'Error in Pauli exponentiation (y**{d} = id) for d={d}'
-            assert z1**(d - z_exp) == id, f'Error in Pauli exponentiation (z**{d} = id) for d={d}'
+            assert x1**d == id, f'Error in Pauli exponentiation (x**{d} = id) for d={d}'
+            assert y1**d == id, f'Error in Pauli exponentiation (y**{d} = id) for d={d}'
+            assert z1**d == id, f'Error in Pauli exponentiation (z**{d} = id) for d={d}'
             assert x1 * id == x1, f'Error in Pauli multiplication (x * id = x) for d={d}'
             assert id * z1 == z1, f'Error in Pauli multiplication (id * z = z) for d={d}'
 

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -466,7 +466,6 @@ class TestPaulis:
             # Generate random dimensions array {d_1, d_2, d_3,...} such that \prod_i d_i <= 10
             dimensions = []
             while True:
-                import random
                 d = random.sample([2, 3, 5], 1)[0]
                 if d * int(np.prod(dimensions)) > 10:
                     break
@@ -618,41 +617,34 @@ class TestPaulis:
         Generate a random PauliSum with mixed dimensions and verify that
         pairwise commutation (via matrices) matches the symplectic scalar product.
         """
-        for _ in range(100):
+        for _ in range(50):
             # number of paulis for each iteration
-            n_paulis = 5
-            # choose random dimensions with product < 16
+            n_paulis = 8
+            # choose random dimensions with product < D
+            D = 100
             dimensions_to_choose_from = [2, 3, 5, 7, 11, 15]
             dimensions = []
-            prod = 1
             while True:
                 d = random.choice(dimensions_to_choose_from)
-                if prod * d >= 16:
+                if d * int(np.prod(dimensions)) > D:
                     break
                 dimensions.append(d)
-                prod *= d
-            if not dimensions:
-                dimensions = [random.choice(dimensions_to_choose_from)]
+
             # generate random PauliSum
             P = PauliSum.from_random(n_paulis, dimensions, rand_phases=True)
             L = P.lcm
             # check commutation relations pairwise
             for i in range(n_paulis):
                 for j in range(i + 1, n_paulis):
-                    # FIXME: make sure that the next two lines select the correct
-                    # PauliStrings INCLUSIVE of phases and weights
-                    psi = P[i].copy()
-                    psj = P[j].copy()
-
+                    psi, psj = P[[i, j]]
                     # scalar symplectic product
                     s = psi.symplectic_product(psj, as_scalar=True)
 
                     # matrix commutator
-                    Mi = PauliSum.from_pauli_strings(psi).to_hilbert_space().toarray()
-                    Mj = PauliSum.from_pauli_strings(psj).to_hilbert_space().toarray()
+                    Mi = psi.to_hilbert_space().toarray()
+                    Mj = psj.to_hilbert_space().toarray()
                     comm = Mi @ Mj - Mj @ Mi
                     is_commuting = np.allclose(comm, np.zeros_like(comm), atol=1e-12)
-
                     # they commute iff scalar symplectic product is 0 (mod L)
                     assert is_commuting == (s == 0), (
                         f"Mismatch commutation for pair ({i},{j}): scalar={s} mod {L}, "
@@ -660,23 +652,20 @@ class TestPaulis:
                         f"PauliStrings:\n{psi}\n{psj}"
                     )
 
-                    # If they do not commute, check that the product (including phase) computed
-                    # from the PauliString matches the direct matrix product Mi @ Mj.
-                    if not is_commuting:
-                        # define product as a PauliString then get its matrix
-                        prod_ps = psi * psj
-                        M_prod_from_ps = PauliSum.from_pauli_strings(prod_ps).to_hilbert_space().toarray()
+                    # define product as a PauliString then get its matrix
+                    prod_ps = psi * psj
+                    M_prod_from_ps = prod_ps.to_hilbert_space().toarray()
 
-                        # directly from matrices
-                        M_prod_direct = Mi @ Mj
+                    # directly from matrices
+                    M_prod_direct = Mi @ Mj
 
-                        # check for phases being handled appropriately
-                        assert np.allclose(M_prod_from_ps, M_prod_direct, atol=1e-12), (
-                            f"Product matrix mismatch for pair ({i},{j}): via PauliString vs direct multiplication\n"
-                            f"element i = {str(psi)}\n "
-                            f"element j = {str(psj)}\n"
-                            f"product i*j = {str(prod_ps)}\n"
-                        )
+                    # check for phases being handled appropriately
+                    assert np.allclose(M_prod_from_ps, M_prod_direct, atol=1e-12), (
+                        f"Product matrix mismatch for pair ({i},{j}): via PauliString vs direct multiplication\n"
+                        f"element i = {str(psi)}\n "
+                        f"element j = {str(psj)}\n"
+                        f"product i*j = {str(prod_ps)}\n"
+                    )
 
     def test_pauli_sum_phase_invariance_matrix_equivalence(self):
         """


### PR DESCRIPTION
## 📝 Description
Adding more unit tests (cherry picked @ldellant branch). I reopened #71 since that branch got too messy to merge after merging integration.

Currently the PR is still a draft until we clarify how to handle phases and weights for Pauli objects. In general, some testing errors were due to the fact that those properties were handled differently for PauliString and Pauli.

A simple solution would be to handle phases and weights at the PauliObject level. If there is a specific need of ignoring phases and weights for PauliStrings, these should be handled explicitly and separately (for instance, if 2 PauliStrings can be considered equal even if their phases differ).

As part of the same PR, we could introduce setters for phases and weights, to simplify their mutation (since this is already done in AQuire). For dimensions and lcm, we could open setters that raise an error or a warning, as they are not intended to be changed (in my understanding).

## ✅ Checklist before requesting a review

- [ ] I have made corresponding changes to the documentation.
- [ ] The code follows the defined style guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] The code passes CI.