### PR TITLE
Fix flaky test

### DIFF
--- a/src/sympleq/core/paulis/pauli.py
+++ b/src/sympleq/core/paulis/pauli.py
@@ -14,14 +14,14 @@ from .constants import DEFAULT_QUDIT_DIMENSION
 
 class Pauli(PauliObject):
     @classmethod
-    def from_tableau(cls, tableau: np.ndarray, dimension: int = DEFAULT_QUDIT_DIMENSION) -> Pauli:
+    def from_tableau(cls, tableau: list[int] | np.ndarray, dimension: int = DEFAULT_QUDIT_DIMENSION) -> Pauli:
         """
         Create a Pauli from its tableau.
 
         Parameters
         ----------
-        tableau : inp.ndarray
-            The tableau of the Pauli, a 1D array of length 2.
+        tableau : list[int] | np.ndarray
+            The tableau of the Pauli, a 1D list or array of length 2.
         dimension : int, optional
             Qudit dimension used to reduce exponents modulo `dimension`.
 
@@ -30,6 +30,9 @@ class Pauli(PauliObject):
         Pauli
             Pauli instance with tableau reduced modulo `dimension`.
         """
+
+        if isinstance(tableau, list):
+            tableau = np.asarray(tableau, dtype=int)
         P = cls(tableau, dimensions=dimension)
         P._sanity_check()
 
@@ -93,6 +96,9 @@ class Pauli(PauliObject):
         """
         tableau = np.empty(2, dtype=int)
         xz_exponents = re.split('x|z', pauli_str)[1:]
+        if len(xz_exponents) != 2:
+            raise ValueError(f"A Pauli has only 1 quidt (got {len(xz_exponents) // 2}).")
+
         x_exp = int(xz_exponents[0])
         z_exp = int(xz_exponents[1])
         tableau[0] = x_exp

--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -170,7 +170,7 @@ class PauliString(PauliObject):
         return P
 
     @classmethod
-    def from_random(cls, dimensions: int | list[int] | np.ndarray, seed=None) -> PauliString:
+    def from_random(cls, dimensions: int | list[int] | np.ndarray, seed: int | None = None) -> PauliString:
         """
         Generate a random PauliString instance for a given number of qudits and their dimensions.
 

--- a/tests/core_tests/paulis_tests/pauli_factory_test.py
+++ b/tests/core_tests/paulis_tests/pauli_factory_test.py
@@ -11,12 +11,26 @@ prime_list = [2, 3, 5, 7, 11, 13]
 class TestPauliSumFactories:
 
     def test_from_pauli_basic(self):
-        ps = PauliString.from_exponents([1, 0], [0, 1], [2, 3])
-        pauli = Pauli(ps.tableau, ps.dimensions, ps.weights, ps.phases)
-        P = PauliSum.from_pauli(pauli)
+        pauli = Pauli.from_string('x1z2', 3)
 
+        ps = PauliString.from_pauli(pauli)
+        assert np.array_equal(ps.tableau, pauli.tableau)
+        assert np.array_equal(ps.dimensions, pauli.dimensions)
+
+        P = PauliSum.from_pauli(pauli)
         assert np.array_equal(P.tableau, pauli.tableau)
         assert np.array_equal(P.dimensions, pauli.dimensions)
+
+        pauli_exp = Pauli.from_exponents(1, 2, 3)
+        assert np.array_equal(pauli_exp.tableau, pauli.tableau)
+        assert np.array_equal(pauli_exp.dimensions, pauli.dimensions)
+
+        pauli_tableau = Pauli.from_tableau([1, 2], 3)
+        assert np.array_equal(pauli_tableau.tableau, pauli.tableau)
+        assert np.array_equal(pauli_tableau.dimensions, pauli.dimensions)
+
+        with pytest.raises(ValueError):
+            pauli = Pauli.from_string('x1z2 x2z2', 3)
 
     def test_from_pauli_strings_single(self):
         ps = PauliString.from_exponents([0, 1], [1, 0], [3, 2])

--- a/tests/core_tests/paulis_tests/pauli_factory_test.py
+++ b/tests/core_tests/paulis_tests/pauli_factory_test.py
@@ -1,0 +1,106 @@
+import numpy as np
+import pytest
+import math
+
+from sympleq.core.paulis import PauliSum, PauliString, Pauli
+
+
+prime_list = [2, 3, 5, 7, 11, 13]
+
+
+class TestPauliSumFactories:
+
+    def test_from_pauli_basic(self):
+        ps = PauliString.from_exponents([1, 0], [0, 1], [2, 3])
+        pauli = Pauli(ps.tableau, ps.dimensions, ps.weights, ps.phases)
+        P = PauliSum.from_pauli(pauli)
+
+        assert np.array_equal(P.tableau, pauli.tableau)
+        assert np.array_equal(P.dimensions, pauli.dimensions)
+
+    def test_from_pauli_strings_single(self):
+        ps = PauliString.from_exponents([0, 1], [1, 0], [3, 2])
+        P = PauliSum.from_pauli_strings(ps, weights=2.0, phases=[1])
+
+        assert P.tableau.shape[0] == 1
+        assert P.weights[0] == 2.0
+        assert P.phases[0] == 1
+
+    def test_from_pauli_strings_multiple(self):
+        ps1 = PauliString.from_exponents([0, 1], [1, 2], [5, 3])
+        ps2 = PauliString.from_exponents([1, 1], [0, 1], [5, 3])
+        P = PauliSum.from_pauli_strings([ps1, ps2], weights=[1.0, 2.0])
+
+        assert P.tableau.shape == (2, ps1.tableau.shape[1])
+        assert np.allclose(P.weights, [1.0, 2.0])
+
+    def test_from_pauli_strings_dimension_mismatch(self):
+        ps1 = PauliString.from_exponents([0], [1], [3])
+        ps2 = PauliString.from_exponents([0, 1], [1, 0], [2, 2])
+        with pytest.raises(ValueError):
+            PauliSum.from_pauli_strings([ps1, ps2])
+
+    def test_from_string(self):
+        ps = PauliString.from_exponents([1, 2], [3, 1], [5, 7])
+        s = str(ps)  # Use the same formatting
+        P = PauliSum.from_string(s, [5, 7])
+
+        assert P.tableau.shape[0] == 1
+
+    def test_from_string_list(self):
+        s1 = "x1z0 x0z2"
+        P = PauliSum.from_string([s1], [3, 3])
+        assert P.tableau.shape[0] == 1
+
+    def test_from_tableau_roundtrip(self):
+        ps = PauliString.from_exponents([1, 0], [2, 0], [5, 7])
+        P = PauliSum.from_pauli_strings(ps)
+        P2 = PauliSum.from_tableau(P.tableau, P.dimensions, P.weights, P.phases)
+
+        assert np.array_equal(P2.tableau, P.tableau)
+        assert np.array_equal(P2.weights, P.weights)
+        assert np.array_equal(P2.phases, P.phases)
+
+    def test_from_random_small_population_no_duplicates(self):
+        dims = [2, 3]  # max_n_paulis = 4 * 9 = 36 < 1e6
+        N = math.prod([d**2 for d in dims])
+        P = PauliSum.from_random(N, dims, seed=123)
+        P.combine_equivalent_paulis()
+
+        assert P.n_paulis() == N
+
+    def test_from_random_large_population_allows_duplicates(self):
+        dims = prime_list
+        N = 300
+        P = PauliSum.from_random(N, dims, seed=123)
+        P.combine_equivalent_paulis()
+
+        assert P.n_paulis() <= N
+
+    def test_from_random_reproducibility(self):
+        dims = [3, 5]
+        P1 = PauliSum.from_random(10, dims, seed=555)
+        P2 = PauliSum.from_random(10, dims, seed=555)
+
+        # Same seeds should give identical tableau/weights/phases
+        assert np.array_equal(P1.tableau, P2.tableau)
+        assert np.allclose(P1.weights, P2.weights)
+        assert np.array_equal(P1.phases, P2.phases)
+
+    def test_from_random_too_many(self):
+        dims = [2, 2]  # max = 16
+        with pytest.raises(ValueError):
+            PauliSum.from_random(17, dims)
+
+    def test_from_random_decoding_correctness_small_population(self):
+        dims = [2, 3]
+        n = 5
+        P = PauliSum.from_random(n, dims, seed=999)
+
+        pauli_strings = [P.select_pauli_string(i) for i in range(P.n_paulis())]
+        for ps in pauli_strings:
+            assert len(ps.x_exp) == len(dims)
+            assert len(ps.z_exp) == len(dims)
+            for xe, ze, d in zip(ps.x_exp, ps.z_exp, dims):
+                assert 0 <= xe < d
+                assert 0 <= ze < d

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -689,8 +689,8 @@ class TestPaulis:
             if not dimensions:
                 dimensions = [random.choice(dimensions_to_choose_from)]
 
-            # random number of paulis
-            n_paulis = random.randint(1, int(max(dimensions)**2))
+            # random number of paulis. Has to be <= 2 * prod to guarantee unique PauliStrings.
+            n_paulis = random.randint(1, 2 * prod)
             P = PauliSum.from_random(n_paulis, dimensions, rand_phases=False)
             n_terms = P.n_paulis()
 

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import random
+import math
 import pytest
 from sympleq.core.paulis import PauliSum, PauliString, Pauli
 from sympleq.core.paulis.constants import DEFAULT_QUDIT_DIMENSION
@@ -689,23 +690,19 @@ class TestPaulis:
             if not dimensions:
                 dimensions = [random.choice(dimensions_to_choose_from)]
 
-            # random number of paulis. Has to be <= 2 * prod to guarantee unique PauliStrings.
-            n_paulis = random.randint(1, 2 * prod)
+            # random number of paulis
+            n_paulis = random.randint(1, math.prod([d**2 for d in dimensions]))
             P = PauliSum.from_random(n_paulis, dimensions, rand_phases=False)
             n_terms = P.n_paulis()
 
-            weights = np.array(P.weights, copy=True)
-            phases = np.array(P.phases, copy=True)
-
             L = P.lcm
-
             # random integer shifts: add up to 2*L - 1
             phase_shifts = np.random.randint(0, 2 * L - 1, size=n_terms)
-            new_phases = (phases + phase_shifts).tolist()
+            new_phases = (P.phases + phase_shifts).tolist()
 
             # fix coefficients accordingly
             # FIXME: ensure weights are correct (notice the "-" sign to undo the added phases above)
-            new_weights = (weights * np.exp(-2j * np.pi * phase_shifts / (2 * L))).tolist()
+            new_weights = (P.weights * np.exp(-2j * np.pi * phase_shifts / (2 * L))).tolist()
 
             # construct new PauliSum
             P_dephased = PauliSum.from_tableau(P.tableau, weights=new_weights,


### PR DESCRIPTION
## 📝 Description
`test_pauli_sum_phase_invariance_matrix_equivalence` was randomly failing because the value for `n_paulis` could randomly be too large to guarantee unique PauliStrings in `PauliSum.from_random`.

It was a more complex fix than expected. Ultimately I chose to split the implementation depending on the maximum possible number of distinct PauliStrings. If this number is less than a certain threshold, I explicitly create a unique set, otherwise we just instantiate random PauliStrings and cross our fingers. The problem is that even for relatively small numbers like n_qudits = 100, n_paulis=20, the naive approach does not work as the number of possible distinct strings grows exponentially.

## ✅ Checklist before requesting a review

- [ ] I have made corresponding changes to the documentation.
- [ ] The code follows the defined style guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] The code passes CI.