### PR TITLE
closes #83 Literal option to is close

### DIFF
--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -224,6 +224,9 @@ class PauliObject(ABC):
             Pauli object to compare against.
         threshold : int, optional
             Number of matching decimal digits required for equality. Default is 10.
+        literal : bool, optional
+            If True, compares objects literally in their current form. If False,
+            accounts for reordering and phases in weights. Default is True.
 
         Returns
         -------

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -234,25 +234,25 @@ class PauliObject(ABC):
             True if all tableau entries, weights, phases, and dimensions
             match within tolerance; False otherwise.
         """
-        self_PauliSum = self.copy()
-        other_PauliSum = other_pauli.copy()
-        if not literal:
-            self_PauliSum = self_PauliSum.to_standard_form()
-            other_PauliSum = other_PauliSum.to_standard_form()
-
         if not isinstance(other_pauli, self.__class__):
             return False
 
-        if not np.array_equal(self_PauliSum.tableau, other_PauliSum.tableau):
+        ps1 = self
+        ps2 = other_pauli
+        if not literal:
+            ps1 = ps1.to_standard_form()
+            ps2 = ps2.to_standard_form()
+
+        if not np.all(np.isclose(ps1.weights, ps2.weights, 10**(-threshold))):
             return False
 
-        if not np.all(np.isclose(self_PauliSum.weights, other_PauliSum.weights, 10**(-threshold))):
+        if not np.array_equal(ps1.phases, ps2.phases):
             return False
 
-        if not np.array_equal(self_PauliSum.phases, other_PauliSum.phases):
+        if not np.array_equal(ps1.dimensions, ps2.dimensions):
             return False
 
-        if not np.array_equal(self_PauliSum.dimensions, other_PauliSum.dimensions):
+        if not np.array_equal(ps1.tableau, ps2.tableau):
             return False
 
         return True

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -214,7 +214,7 @@ class PauliObject(ABC):
         """
         pass
 
-    def is_close(self, other_pauli: Self, threshold: int = 10) -> bool:
+    def is_close(self, other_pauli: Self, threshold: int = 10, literal: bool = True) -> bool:
         """
         Check whether two Pauli objects are approximately equal.
 
@@ -231,19 +231,25 @@ class PauliObject(ABC):
             True if all tableau entries, weights, phases, and dimensions
             match within tolerance; False otherwise.
         """
+        self_PauliSum = self.copy()
+        other_PauliSum = other_pauli.copy()
+        if not literal:
+            self_PauliSum = self_PauliSum.to_standard_form()
+            other_PauliSum = other_PauliSum.to_standard_form()
+
         if not isinstance(other_pauli, self.__class__):
             return False
 
-        if not np.array_equal(self.tableau, other_pauli.tableau):
+        if not np.array_equal(self_PauliSum.tableau, other_PauliSum.tableau):
             return False
 
-        if not np.all(np.isclose(self.weights, other_pauli.weights, 10**(-threshold))):
+        if not np.all(np.isclose(self_PauliSum.weights, other_PauliSum.weights, 10**(-threshold))):
             return False
 
-        if not np.array_equal(self.phases, other_pauli.phases):
+        if not np.array_equal(self_PauliSum.phases, other_PauliSum.phases):
             return False
 
-        if not np.array_equal(self.dimensions, other_pauli.dimensions):
+        if not np.array_equal(self_PauliSum.dimensions, other_PauliSum.dimensions):
             return False
 
         return True
@@ -291,7 +297,7 @@ class PauliObject(ABC):
             True if the object equals its Hermitian conjugate; False otherwise.
         """
         # NOTE: rounding errors could make this fail, hence we call the is_close function.
-        return self.to_standard_form().is_close(self.H().to_standard_form())
+        return self.is_close(self.H(), literal=False)
 
     def _sanity_check(self):
         """

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -742,7 +742,8 @@ class TestPaulis:
         # literal = False
         psum1 = PauliSum.from_pauli_strings([ps1, ps2], weights=[1.0, 0.5], phases=[0, 1])
         psum1.phase_to_weight()
-        psum2 = PauliSum.from_pauli_strings([ps1, ps2], weights=[1.0 + 1e-12, 0.5 - 1e-12], phases=[0, 1])
+        psum2 = PauliSum.from_pauli_strings([ps1, ps2], weights=[1.0, 0.5], phases=[0, 1])
+        assert not psum1.is_close(psum2, literal=True)
         assert psum1.is_close(psum2, literal=False)
 
         psum1 = PauliSum.from_pauli_strings([ps2, ps1], weights=[0.5, 1.0], phases=[1, 0])


### PR DESCRIPTION
## 📝 Description
Added a toggle to PauliSum.is_close() called "literal" that compares PauliSums to another literally (meaning both phases, weights, and paulistrings have to match not only in there values but also in their order) if true, and if false first standadises them, thus accounting for changes in order and phases that might be already merged with the weights

## ✅ Checklist before requesting a review

- [x] I have made corresponding changes to the documentation.
- [x] The code follows the defined style guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] The code passes CI.