### PR TITLE
Handle phases and weights in PauliObject

### DIFF
--- a/src/sympleq/core/paulis/pauli.py
+++ b/src/sympleq/core/paulis/pauli.py
@@ -184,32 +184,6 @@ class Pauli(PauliObject):
         return cls.from_exponents(0, 0, dimension)
 
     @property
-    def phases(self) -> np.ndarray:
-        """
-        Returns the phases associated with the Pauli.
-        For a Pauli operator, this is just the trivial phase.
-
-        Returns
-        -------
-        np.ndarray
-            The phases as a 1d-vector.
-        """
-        return np.asarray([0], dtype=int)
-
-    @property
-    def weights(self) -> np.ndarray:
-        """
-        Returns the weights associated with the Pauli.
-        For a Pauli operator, this is just 1.
-
-        Returns
-        -------
-        np.ndarray
-            The weights as a 1d-vector.
-        """
-        return np.asarray([1], dtype=complex)
-
-    @property
     def dimension(self) -> int:
         """
         Returns the dimension of the Pauli as an int.

--- a/src/sympleq/core/paulis/pauli.py
+++ b/src/sympleq/core/paulis/pauli.py
@@ -265,19 +265,6 @@ class Pauli(PauliObject):
 
         return Pauli(new_tableau, dimensions=self.dimensions)
 
-    def __repr__(self) -> str:
-        """
-        Return the string representation of the Pauli.
-        (in a format that is helpful for debugging).
-
-        Returns
-        -------
-        str
-            A string in the format "Pauli(x_exp=..., z_exp=..., dimensions=...)".
-        """
-
-        return f"PauliString(tableau={self.tableau}, dimensions={self.dimensions})"
-
     def __str__(self) -> str:
         """
         String representation in the form 'x{X}z{Z}'.

--- a/src/sympleq/core/paulis/pauli.py
+++ b/src/sympleq/core/paulis/pauli.py
@@ -206,7 +206,7 @@ class Pauli(PauliObject):
         """
         # FIXME: import at the top. Currently we can't because of circular imports.
         from .pauli_sum import PauliSum
-        return PauliSum(self._tableau, self._dimensions, self._weights, self._phases)
+        return PauliSum(self.tableau, self.dimensions, self.weights, self.phases)
 
     def as_pauli_string(self) -> PauliString:
         """
@@ -219,7 +219,7 @@ class Pauli(PauliObject):
         """
         # FIXME: import at the top. Currently we can't because of circular imports.
         from .pauli_string import PauliString
-        return PauliString(self._tableau, self._dimensions, self._weights, self._phases)
+        return PauliString(self.tableau, self.dimensions, self.weights, self.phases)
 
     def to_hilbert_space(self) -> sp.csr_matrix:
         """

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -69,6 +69,7 @@ class PauliObject(ABC):
                 dimensions = np.full(n_qudits, dimensions.item(), dtype=int)
 
         self._dimensions = dimensions
+        # Dimensions is read-only, so any type of assignment will fail.
         self._dimensions.setflags(write=False)
         self._lcm = int(np.lcm.reduce(self.dimensions))
 
@@ -119,6 +120,8 @@ class PauliObject(ABC):
 
     @dimensions.setter
     def dimensions(self, value: np.ndarray):
+        # Dimensions is read-only, and this setter is not strictly required.
+        # We keep it to raise with a meaningful error message.
         raise Exception("The dimensions of a PauliObject cannot be set.\
                         If you want to change the PauliObject dimensions, generate a new one.")
 
@@ -188,14 +191,13 @@ class PauliObject(ABC):
 
     @phases.setter
     def phases(self, new_phases: list[int] | np.ndarray):
-        if isinstance(new_phases, list):
-            new_phases = np.asarray(new_phases, dtype=int)
+        new_phases = np.asarray(new_phases, dtype=int)
 
         if len(new_phases) != self.n_paulis():
             raise ValueError(
-                f"New phases ({len(new_phases)}) length must equal the number of Pauli strings ({self.n_paulis()}.")
+                f"New phases ({len(new_phases)}) length must equal the number of Pauli strings ({self.n_paulis()}).")
 
-        self._phases = new_phases
+        self._phases = new_phases % (2 * self.lcm)
 
     def set_phases(self, new_phases: list[int] | np.ndarray):
         """
@@ -237,12 +239,11 @@ class PauliObject(ABC):
 
     @weights.setter
     def weights(self, new_weights: list[int] | np.ndarray):
-        if isinstance(new_weights, list):
-            new_weights = np.asarray(new_weights, dtype=int)
+        new_weights = np.asarray(new_weights, dtype=complex)
 
         if len(new_weights) != self.n_paulis():
             raise ValueError(
-                f"New phases ({len(new_weights)}) length must equal the number of Pauli strings ({self.n_paulis()}.")
+                f"New weights ({len(new_weights)}) length must equal the number of Pauli strings ({self.n_paulis()}).")
 
         self._weights = new_weights
 

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -390,6 +390,17 @@ class PauliObject(ABC):
                 f"tableau={self.tableau[bad_indices]}"
             )
 
+    def __repr__(self) -> str:
+        """
+        Returns an unambiguous string representation of the PauliObject.
+
+        Returns
+        -------
+        str
+            A string representation of the PauliObject with tableau, dimensions, weights, and phases.
+        """
+        return f'{self.__class__.__name__}({self.tableau}, {self.dimensions}, {self.weights}, {self.phases})'
+
     def __eq__(self, other_pauli: Self) -> bool:
         """
         Determine if two Pauli objects are equal.

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -75,7 +75,7 @@ class PauliObject(ABC):
         self._dimensions.setflags(write=False)
         self._lcm = int(np.lcm.reduce(self.dimensions))
 
-        self._tableau = tableau % np.tile(self._dimensions, 2)
+        self._tableau = tableau % np.tile(self.dimensions, 2)
 
         if weights is None:
             weights = np.ones(n_pauli_strings, dtype=complex)
@@ -225,7 +225,7 @@ class PauliObject(ABC):
         None
             This method modifies the object in place.
         """
-        self._phases = np.zeros(len(self._phases))
+        self._phases = np.zeros(len(self.phases))
 
     @property
     def weights(self) -> np.ndarray:
@@ -273,7 +273,7 @@ class PauliObject(ABC):
         None
             This method modifies the object in place.
         """
-        self._weights = np.ones(len(self._weights))
+        self._weights = np.ones(len(self.weights))
 
     def has_equal_tableau(self, other_pauli: PauliObject, literal: bool = True) -> bool:
         """
@@ -376,7 +376,7 @@ class PauliObject(ABC):
             acquired_phases.append(2 * hermitian_conjugate_phase)
         acquired_phases = np.asarray(acquired_phases, dtype=int)
 
-        conjugate_initial_phases = (-self._phases) % (2 * self.lcm)
+        conjugate_initial_phases = (-self.phases) % (2 * self.lcm)
         conjugate_phases = (conjugate_initial_phases + acquired_phases) % (2 * self.lcm)
 
         return self.__class__(tableau=conjugate_tableau, dimensions=self.dimensions,
@@ -756,7 +756,7 @@ class PauliObject(ABC):
             raise Exception("A Pauli object with more than a PauliString cannot be exponentiated.")
 
         tableau = np.mod(self.tableau * A, np.tile(self.dimensions, 2))
-        return self.__class__(tableau, self._dimensions.copy(), self._weights.copy(), self._phases.copy())
+        return self.__class__(tableau, self.dimensions.copy(), self.weights.copy(), self.phases.copy())
 
     def __hash__(self) -> int:
         """
@@ -796,10 +796,8 @@ class PauliObject(ABC):
         -------
         Pauli object
             A copy of the Pauli object.
-        Pauli object
-            A copy of the Pauli object.
         """
-        return self.__class__(self._tableau.copy(), self._dimensions.copy(), self._weights.copy(), self._phases.copy())
+        return self.__class__(self.tableau.copy(), self.dimensions.copy(), self.weights.copy(), self.phases.copy())
 
     def phase_to_weight(self):
         """
@@ -809,7 +807,7 @@ class PauliObject(ABC):
         """
         new_weights = np.zeros(self.n_paulis(), dtype=np.complex128)
         for i in range(self.n_paulis()):
-            phase = self._phases[i]
+            phase = self.phases[i]
             omega = np.exp(2 * np.pi * 1j * phase / (2 * self.lcm))
             new_weights[i] = self.weights[i] * omega
         self._phases = np.zeros(self.n_paulis(), dtype=int)

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -117,6 +117,11 @@ class PauliObject(ABC):
         """
         return self._dimensions
 
+    @dimensions.setter
+    def dimensions(self, value: np.ndarray):
+        raise Exception("The dimensions of a PauliObject cannot be set.\
+                        If you want to change the PauliObject dimensions, generate a new one.")
+
     @property
     def lcm(self) -> int:
         """
@@ -128,6 +133,11 @@ class PauliObject(ABC):
             The least common multiple of the qudit dimensions.
         """
         return self._lcm
+
+    @lcm.setter
+    def lcm(self, value: int):
+        raise Exception("The lcm of a PauliObject cannot be set, as it is derived from its dimensions.\
+                        If you want to change the PauliObject dimensions, generate a new one.")
 
     def n_qudits(self) -> int:
         """

--- a/src/sympleq/core/paulis/pauli_object.py
+++ b/src/sympleq/core/paulis/pauli_object.py
@@ -262,6 +262,39 @@ class PauliObject(ABC):
         """
         self._weights = np.ones(len(self._weights))
 
+    def has_equal_tableau(self, other_pauli: PauliObject, literal: bool = True) -> bool:
+        """
+        Check whether two Pauli objects have the same tableau and dimensions.
+
+        Parameters
+        ----------
+        other_pauli : PauliObject
+            Pauli object to compare against.
+
+        literal : bool, optional
+            If True, compares objects literally in their current form. If False,
+            the objects are first brought to standard form. Default is True.
+
+        Returns
+        -------
+        bool
+            True if all tableau entries and dimensions match; False otherwise.
+        """
+
+        ps1 = self
+        ps2 = other_pauli
+        if not literal:
+            ps1 = ps1.to_standard_form()
+            ps2 = ps2.to_standard_form()
+
+        if not np.array_equal(ps1.dimensions, ps2.dimensions):
+            return False
+
+        if not np.array_equal(ps1.tableau, ps2.tableau):
+            return False
+
+        return True
+
     def is_close(self, other_pauli: Self, threshold: int = 10, literal: bool = True) -> bool:
         """
         Check whether two Pauli objects are approximately equal.
@@ -274,7 +307,7 @@ class PauliObject(ABC):
             Number of matching decimal digits required for equality. Default is 10.
         literal : bool, optional
             If True, compares objects literally in their current form. If False,
-            accounts for reordering and phases in weights. Default is True.
+            the objects are first brought to standard form. Default is True.
 
         Returns
         -------

--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -377,30 +377,6 @@ class PauliString(PauliObject):
         """
         return self._tableau[0][self.n_qudits():]
 
-    @property
-    def phases(self) -> np.ndarray:
-        """
-        Returns the phases associated with the PauliString.
-
-        Returns
-        -------
-        np.ndarray
-            The phases as a 1d-vector.
-        """
-        return np.asarray([0], dtype=int)
-
-    @property
-    def weights(self) -> np.ndarray:
-        """
-        Returns the weights associated with the Pauli String.
-
-        Returns
-        -------
-        np.ndarray
-            The weights as a 1d-vector.
-        """
-        return np.asarray([1], dtype=complex)
-
     def as_pauli_sum(self) -> PauliSum:
         """
         Converts the PauliString to the embedding PauliSum.

--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -328,12 +328,12 @@ class PauliString(PauliObject):
 
         tableau = np.mod(self.tableau + A.tableau, np.tile(self.dimensions, 2))
 
-        w1 = self._weights[:, None]
-        w2 = A._weights[None, :]
+        w1 = self.weights[:, None]
+        w2 = A.weights[None, :]
         new_weights = (w1 * w2).reshape(-1)
 
-        p1 = self._phases[:, None]
-        p2 = A._phases[None, :]
+        p1 = self.phases[:, None]
+        p2 = A.phases[None, :]
 
         # Extract z- and x-parts from tableau
         n1, n2 = self.n_qudits(), A.n_qudits()
@@ -354,7 +354,7 @@ class PauliString(PauliObject):
         x_exp : np.ndarray
         Array of X exponents for each qudit.
         """
-        return self._tableau[0][:self.n_qudits()]
+        return self.tableau[0][:self.n_qudits()]
 
     @property
     def z_exp(self) -> np.ndarray:
@@ -362,7 +362,7 @@ class PauliString(PauliObject):
         z_exp : np.ndarray
         Array of Z exponents for each qudit.
         """
-        return self._tableau[0][self.n_qudits():]
+        return self.tableau[0][self.n_qudits():]
 
     def as_pauli_sum(self) -> PauliSum:
         """
@@ -375,7 +375,7 @@ class PauliString(PauliObject):
         """
         # FIXME: import at the top. Currently we can't because of circular imports.
         from .pauli_sum import PauliSum
-        return PauliSum(self._tableau, self._dimensions, self._weights, self._phases)
+        return PauliSum(self.tableau, self.dimensions, self.weights, self.phases)
 
     def n_identities(self) -> int:
         """
@@ -648,7 +648,7 @@ class PauliString(PauliObject):
         if isinstance(key, np.ndarray):
             tableau_mask = np.concatenate([key, key + self.n_qudits()])
             return PauliString(
-                self.tableau[tableau_mask], self.dimensions[key], self._weights, self._phases)
+                self.tableau[tableau_mask], self.dimensions[key], self.weights, self.phases)
 
         raise ValueError(f"Cannot get item with key {key}. Key must be aof type int, slice, np.ndarray, or list[int].")
 
@@ -722,7 +722,7 @@ class PauliString(PauliObject):
         """
 
         dimensions = self.dimensions[qudit_indices]
-        tableau = self._tableau[0][qudit_indices]
+        tableau = self.tableau[0][qudit_indices]
 
         return PauliString(tableau, dimensions)
 

--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -198,19 +198,6 @@ class PauliString(PauliObject):
         tableau = np.concatenate([np.random.randint(dimensions, dtype=int), np.random.randint(dimensions, dtype=int)])
         return cls(tableau, dimensions)
 
-    def __repr__(self) -> str:
-        """
-        Return the string representation of the PauliString.
-        (in a format that is helpful for debugging).
-
-        Returns
-        -------
-        str
-            A string in the format "PauliString(tableau=..., dimensions=...)".
-        """
-
-        return f"PauliString(tableau={self.tableau}, dimensions={self.dimensions})"
-
     def __str__(self) -> str:
         """
         Return the string representation of the PauliString.

--- a/src/sympleq/core/paulis/pauli_sum.py
+++ b/src/sympleq/core/paulis/pauli_sum.py
@@ -1113,17 +1113,6 @@ class PauliSum(PauliObject):
             p_string += f'{self.weights[i]}' + ' ' * n_spaces + '|' + qudit_string + f'| {self.phases[i]} \n'
         return p_string
 
-    def __repr__(self) -> str:
-        """
-        Returns an unambiguous string representation of the PauliSum.
-
-        Returns
-        -------
-        str
-            A string representation of the PauliSum with tableau, dimensions, weights, and phases.
-        """
-        return f'PauliSum({self.tableau}, {self.dimensions}, {self.weights}, {self.phases})'
-
     def get_subspace(self,
                      qudit_indices: int | list[int] | np.ndarray,
                      pauli_indices: int | list[int] | np.ndarray | None = None):

--- a/src/sympleq/core/paulis/pauli_sum.py
+++ b/src/sympleq/core/paulis/pauli_sum.py
@@ -162,12 +162,12 @@ class PauliSum(PauliObject):
                 if not np.array_equal(ps.dimensions, dimensions):
                     raise ValueError("The dimensions of all Pauli strings must be equal.")
 
-        tableau = np.vstack([p._tableau for p in pauli_string])
+        tableau = np.vstack([p.tableau for p in pauli_string])
 
         if inherit_phases:
             if phases is not None:
                 warnings.warn("Phases are disregarded if inherit_phases is set to True.")
-            phases = np.hstack([p._phases for p in pauli_string])
+            phases = np.hstack([p.phases for p in pauli_string])
         return cls(tableau, dimensions, weights, phases)
 
     @classmethod
@@ -579,7 +579,7 @@ class PauliSum(PauliObject):
         """
 
         if isinstance(A, ScalarType):
-            return PauliSum(self._tableau, self._dimensions, self._weights * A, self._phases)
+            return PauliSum(self.tableau, self.dimensions, self.weights * A, self.phases)
 
         if isinstance(A, Pauli):
             return self * A.as_pauli_sum()
@@ -769,14 +769,14 @@ class PauliSum(PauliObject):
                 if ps1 == ps2:
                     # FIXME: can overflow for very large n_paulis.
                     #        One solution could be to normalize it by dividing by the smallest weight.
-                    self._weights[i] = self._weights[i] + self._weights[j]
+                    self._weights[i] = self.weights[i] + self.weights[j]
                     to_delete.append(j)
         self._delete_paulis(to_delete)
 
         # remove zero weight Paulis
         to_delete = []
         for i in range(self.n_paulis()):
-            if self._weights[i] == 0:
+            if self.weights[i] == 0:
                 to_delete.append(i)
         self._delete_paulis(to_delete)
 
@@ -940,9 +940,9 @@ class PauliSum(PauliObject):
         if isinstance(pauli_indices, int):
             pauli_indices = [pauli_indices]
 
-        self._weights = np.delete(self._weights, pauli_indices)
-        self._phases = np.delete(self._phases, pauli_indices)
-        self._tableau = np.delete(self._tableau, pauli_indices, axis=0)
+        self._weights = np.delete(self.weights, pauli_indices)
+        self._phases = np.delete(self.phases, pauli_indices)
+        self._tableau = np.delete(self.tableau, pauli_indices, axis=0)
 
     def _delete_qudits(self, qudit_indices: list[int] | int):
         """
@@ -960,11 +960,11 @@ class PauliSum(PauliObject):
         mask[qudit_indices] = False
 
         # Note: we first delete the rightmost indices, so they are not shifted.
-        self._tableau = np.delete(self._tableau, [idx + self.n_qudits() for idx in qudit_indices], axis=1)
-        self._tableau = np.delete(self._tableau, qudit_indices, axis=1)
+        self._tableau = np.delete(self.tableau, [idx + self.n_qudits() for idx in qudit_indices], axis=1)
+        self._tableau = np.delete(self.tableau, qudit_indices, axis=1)
 
-        self._dimensions = self._dimensions[mask]
-        self._lcm = int(np.lcm.reduce(self._dimensions))
+        self._dimensions = self.dimensions[mask]
+        self._lcm = int(np.lcm.reduce(self.dimensions))
 
     def symplectic_product_matrix(self) -> np.ndarray:
         """
@@ -1194,12 +1194,12 @@ class PauliSum(PauliObject):
 
         self._weights = np.array([self.weights[i] for i in order])
         self._phases = np.array([self.phases[i] for i in order])
-        self._tableau = np.array([self._tableau[i] for i in order])
+        self._tableau = np.array([self.tableau[i] for i in order])
 
     def swap_paulis(self, index_1: int, index_2: int):
         self._weights[index_1], self._weights[index_2] = self.weights[index_2], self.weights[index_1]
         self._phases[index_1], self._phases[index_2] = self.phases[index_2], self.phases[index_1]
-        self._tableau[index_1], self._tableau[index_2] = self._tableau[index_2], self._tableau[index_1]
+        self._tableau[index_1], self._tableau[index_2] = self.tableau[index_2], self.tableau[index_1]
 
     # def hermitian_conjugate(self):
     #     conjugate_weights = np.conj(self.weights)

--- a/src/sympleq/core/paulis/pauli_sum.py
+++ b/src/sympleq/core/paulis/pauli_sum.py
@@ -268,29 +268,6 @@ class PauliSum(PauliObject):
 
         return cls.from_pauli_strings(pauli_strings, weights=weights, phases=phases)
 
-    @property
-    def phases(self) -> np.ndarray:
-        """
-        Returns the phases associated with the PauliSum.
-        These phases represent the numerator, the denominator is 2 * self.lcm
-
-        Returns
-        -------
-        np.ndarray
-            The phases as a 1d-vector.
-        """
-        return self._phases
-
-    def set_phases(self, new_phases: list[int] | np.ndarray):
-        if isinstance(new_phases, list):
-            new_phases = np.asarray(new_phases, dtype=int)
-
-        if len(new_phases) != self.n_paulis():
-            raise ValueError(
-                f"New phases ({len(new_phases)}) length must equal the number of Pauli strings ({self.n_paulis()}.")
-
-        self._phases = new_phases
-
     def weight_to_phase(self):
         """
         Extract per-term phases from complex weights onto the integer phase vector.
@@ -354,28 +331,6 @@ class PauliSum(PauliObject):
         # commit
         self._phases = new_phases
         self._weights = np.round(new_weights, 10)
-
-    @property
-    def weights(self) -> np.ndarray:
-        """
-        Returns the weights associated with the PauliSum.
-
-        Returns
-        -------
-        np.ndarray
-            The weights as a 1d-vector.
-        """
-        return self._weights
-
-    def set_weights(self, new_weights: list[int] | np.ndarray):
-        if isinstance(new_weights, list):
-            new_weights = np.asarray(new_weights, dtype=int)
-
-        if len(new_weights) != self.n_paulis():
-            raise ValueError(
-                f"New phases ({len(new_weights)}) length must equal the number of Pauli strings ({self.n_paulis()}.")
-
-        self._weights = new_weights
 
     @overload
     def __getitem__(self,

--- a/tests/core_tests/circuits_tests/gates_test.py
+++ b/tests/core_tests/circuits_tests/gates_test.py
@@ -156,9 +156,9 @@ class TestGates():
                 output_str_correct = f"x{(-s1) % d}z{r1} x{r2}z{s2}"
 
                 output_ps = gate.act(input_ps)
-                assert output_ps == PauliString.from_string(
+                assert output_ps.has_equal_tableau(PauliString.from_string(
                     output_str_correct, dimensions=[d, d]
-                ), 'Error in Hadamard gate 0'
+                )), 'Error in Hadamard gate 0'
 
             gate = Hadamard(1, d, inverse=False)  # Hadamard on qudit 1
             for i in range(100):
@@ -166,9 +166,9 @@ class TestGates():
                 output_str_correct = f"x{r1}z{s1} x{(-s2) % d}z{r2}"
 
                 output_ps = gate.act(input_ps)
-                assert output_ps == PauliString.from_string(
+                assert output_ps.has_equal_tableau(PauliString.from_string(
                     output_str_correct, dimensions=[d, d]
-                ), 'Error in Hadamard gate 1'
+                )), 'Error in Hadamard gate 1'
             # test pauli_sums
             gate = Hadamard(0, d, inverse=False)  # Hadamard on qubit 0
 
@@ -188,7 +188,7 @@ class TestGates():
                 output_psum = gate.act(input_psum)
                 output_psum_correct = PauliSum.from_pauli_strings(
                     ps_list_out_correct, phases=ps_phase_out_correct)
-                assert output_psum == output_psum_correct, (
+                assert output_psum.has_equal_tableau(output_psum_correct), (
                     'Error in Hadamard gate: \n' +
                     input_psum.__str__() + '\n' +
                     output_psum.__str__() + '\n' +
@@ -205,7 +205,8 @@ class TestGates():
                 output_str_correct = f"x{r1}z{(r1 + s1) % d} x{r2}z{s2}"
 
                 output_ps = gate.act(input_ps)
-                assert output_ps == PauliString.from_string(output_str_correct, dimensions=[d, d]), 'Error in H gate 0'
+                assert output_ps.has_equal_tableau(PauliString.from_string(
+                    output_str_correct, dimensions=[d, d])), 'Error in H gate 0'
 
             gate = PHASE(1, d)  # PHASE on qudit 1
             for i in range(100):
@@ -213,7 +214,8 @@ class TestGates():
                 output_str_correct = f"x{r1}z{s1} x{r2}z{(r2 + s2) % d}"
 
                 output_ps = gate.act(input_ps)
-                assert output_ps == PauliString.from_string(output_str_correct, dimensions=[d, d]), 'Error in H gate 1'
+                assert output_ps.has_equal_tableau(PauliString.from_string(
+                    output_str_correct, dimensions=[d, d])), 'Error in H gate 1'
             # test pauli_sums
             gate = PHASE(0, d)  # PHASE on qubit 0
             h = gate.phase_vector
@@ -244,7 +246,7 @@ class TestGates():
                 output_psum = gate.act(input_psum)
                 output_psum_correct = PauliSum.from_pauli_strings(
                     ps_list_out_correct, phases=ps_phase_out_correct)
-                assert output_psum == output_psum_correct, (
+                assert output_psum.has_equal_tableau(output_psum_correct), (
                     'Error in Hadamard gate: \n' +
                     input_psum.__str__() + '\n' +
                     output_psum.__str__() + '\n' +

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -87,9 +87,9 @@ class TestPaulis:
                 input_ps2 = PauliString.from_string(input_str2, dimensions=[dim, dim])
                 output_ps = input_ps1 * input_ps2
 
-                assert output_ps == PauliString.from_string(
+                assert output_ps.has_equal_tableau(PauliString.from_string(
                     output_str_correct, dimensions=[dim, dim]
-                ), 'Error in PauliString multiplication'
+                )), 'Error in PauliString multiplication'
 
     def test_pauli_string_tensor_product(self):
         for dimensions in prime_list:
@@ -381,7 +381,8 @@ class TestPaulis:
                                       phases=[0, 0, phases_correction, phases_correction],
                                       dimensions=dims)
 
-            assert s1 * s2 == s3, f'Expected s1 * s2 to equal s3, got \n{s1 * s2}\n instead of \n{s3}\n'
+            assert (
+                s1 * s2).has_equal_tableau(s3), f'Expected s1 * s2 to equal s3, got \n{s1 * s2}\n instead of \n{s3}\n'
 
     def test_tensor_product_distributivity(self):
 
@@ -418,7 +419,7 @@ class TestPaulis:
             n_qudits = len(dimensions)
 
             # Generate random PauliStrings
-            pauli_strings = []
+            pauli_strings: list[PauliString] = []
             for _ in range(n_paulis):
                 ps = PauliString.from_exponents(
                     x_exp=[random.randint(0, d - 1) for d in dimensions],
@@ -436,7 +437,7 @@ class TestPaulis:
 
             # Test single indexing
             for i in range(n_paulis):
-                assert ps.select_pauli_string(i) == pauli_strings[i], \
+                assert ps.select_pauli_string(i).has_equal_tableau(pauli_strings[i]), \
                     f'Error in PauliSum single indexing at position {i}'
 
             # Test slice indexing
@@ -447,7 +448,7 @@ class TestPaulis:
                     weights=weights[slice_idx],
                     phases=phases[slice_idx]
                 )
-                assert ps[slice_idx] == expected_slice, 'Error in PauliSum slice indexing'
+                assert ps[slice_idx].has_equal_tableau(expected_slice), 'Error in PauliSum slice indexing'
 
             # Test list indexing (select multiple Pauli strings)
             if n_paulis >= 2:
@@ -457,7 +458,7 @@ class TestPaulis:
                     weights=[weights[i] for i in idx_list],
                     phases=[phases[i] for i in idx_list]
                 )
-                assert ps[idx_list] == expected_list, 'Error in PauliSum list indexing'
+                assert ps[idx_list].has_equal_tableau(expected_list), 'Error in PauliSum list indexing'
 
             # Test combined indexing (select Pauli strings and qudits)
             if n_paulis >= 2 and n_qudits >= 1:
@@ -465,11 +466,11 @@ class TestPaulis:
                 qudit_idx = random.randint(0, n_qudits - 1)
 
                 expected_combined = PauliSum.from_pauli_strings(
-                    [pauli_strings[i][qudit_idx] for i in idx_list],
+                    [pauli_strings[i][qudit_idx] for i in idx_list],  # type: ignore
                     weights=[weights[i] for i in idx_list],
                     phases=[phases[i] for i in idx_list]
                 )
-                assert ps[idx_list, qudit_idx] == expected_combined, \
+                assert ps[idx_list, qudit_idx].has_equal_tableau(expected_combined), \
                     'Error in PauliSum combined indexing (list, single qudit)'
 
             # Test combined indexing with multiple qudits
@@ -486,7 +487,7 @@ class TestPaulis:
                     weights=[weights[i] for i in idx_list],
                     phases=[phases[i] for i in idx_list]
                 )
-                assert ps[idx_list, qudit_list] == expected_multi, \
+                assert ps[idx_list, qudit_list].has_equal_tableau(expected_multi), \
                     'Error in PauliSum combined indexing (list, list)'
 
     def test_pauli_sum_amend(self):
@@ -658,35 +659,35 @@ class TestPaulis:
             dim = random.choices(prime_list, k=1)
             P1 = PauliString.from_string('x1z0', dimensions=dim)
             P2 = PauliString.from_string(f'x{dim[0] - 1}z0', dimensions=dim)
-            assert P1.H() == P2
+            assert P1.H().has_equal_tableau(P2)
         P1 = PauliString.from_string('x1z1', dimensions=dim)
         P2 = PauliString.from_string(f'x{dim[0] - 1}z{dim[0] - 1}', dimensions=dim)
-        assert P1.H() == P2
+        assert P1.H().has_equal_tableau(P2)
 
         P1 = PauliString.from_string(f'x{dim[0] - 1}z1', dimensions=dim)
         P2 = PauliString.from_string(f'x1z{dim[0] - 1}', dimensions=dim)
-        assert P1.H() == P2
+        assert P1.H().has_equal_tableau(P2)
 
         P1 = PauliString.from_string('x0z0', dimensions=dim)
         P2 = PauliString.from_string('x0z0', dimensions=dim)
-        assert P1.H() == P2
+        assert P1.H().has_equal_tableau(P2)
         assert P1.is_hermitian()
 
         dim = random.choices(prime_list, k=2)
         P1 = PauliString.from_string('x0z1 x1z1', dimensions=dim)
         P2 = PauliString.from_string(f'x0z{dim[0] - 1} x{dim[1] - 1}z{dim[1] - 1}', dimensions=dim)
-        assert P1.H() == P2
+        assert P1.H().has_equal_tableau(P2)
 
         P1 = PauliString.from_string('x0z1 x1z0', dimensions=dim)
         P2 = PauliString.from_string(f'x0z{dim[0] - 1} x{dim[1] - 1}z0', dimensions=dim)
-        assert P1.H() == P2
+        assert P1.H().has_equal_tableau(P2)
 
         dim = random.choices(prime_list, k=2)
         while dim[0] == 2:
             dim = random.choices(prime_list, k=2)
         P1 = PauliString.from_string('x2z1 x0z1', dimensions=dim)
         P2 = PauliString.from_string(f'x{dim[0] - 2}z{dim[0] - 1} x0z{dim[1] - 1}', dimensions=dim)
-        assert P1.H() == P2
+        assert P1.H().has_equal_tableau(P2)
 
     def test_pauli_sum_is_hermitian(self):
         for run in range(int(np.ceil(np.sqrt(N_tests)))):

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -973,7 +973,27 @@ class TestPaulis:
             p.dimensions = np.array([2], dtype=int)
 
         p = PauliSum.from_random(4, [2, 3, 5])
+
+        # Cannot set lcm
         with pytest.raises(Exception):
             p.lcm = 24
+
+        # Cannot set dimensions
         with pytest.raises(Exception):
             p.dimensions = np.array([2], dtype=int)
+
+        # Dimensions is read-only
+        with pytest.raises(Exception):
+            p.dimensions[0] = 2
+
+        # Invalid phases length
+        with pytest.raises(ValueError):
+            p.phases[:] = np.array([2.4, 1, 0])
+
+        # Cannot convert complex to int
+        with pytest.raises(TypeError):
+            p.phases[0] = 2.4j
+
+        # Invalid weights length
+        with pytest.raises(ValueError):
+            p.weights[:] = np.array([2.4, 1, 0])

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -958,3 +958,22 @@ class TestPaulis:
         psum1.phase_to_weight()
         psum2 = PauliSum.from_pauli_strings([ps1, ps2], weights=[1.0 + 1e-12, 0.5 - 1e-12], phases=[0, 1])
         assert not psum1.is_close(psum2, literal=False)
+
+    def test_pauli_object_invalid_setters(self):
+        p = Pauli.Xnd(1, 2)
+        with pytest.raises(Exception):
+            p.lcm = 2
+        with pytest.raises(Exception):
+            p.dimensions = np.array([2], dtype=int)
+
+        p = PauliString.from_random([2, 3, 5])
+        with pytest.raises(Exception):
+            p.lcm = 12
+        with pytest.raises(Exception):
+            p.dimensions = np.array([2], dtype=int)
+
+        p = PauliSum.from_random(4, [2, 3, 5])
+        with pytest.raises(Exception):
+            p.lcm = 24
+        with pytest.raises(Exception):
+            p.dimensions = np.array([2], dtype=int)


### PR DESCRIPTION
## 📝 Description
Handle phases and weights consistently for PauliObjects. This means that phases and weights are also relevant for PauliString and Pauli objects.

- [x] Move phases and weights to PauliObject
- [x] Add setters
- [x] Add `had_equivalent_tableau` function to compare two PauliObjects disregarding phases and weights (not sure about the name)
- [x] Raise error if someone tries to set `_dimensions` or `_lcm`
- [x] Use either underscored or public properties consistently in internal methods
- [x] Update tests   
- [x] (Bonus) Move `__repr__` function to PauliObject

Another approach would be to override the `__eq__` behaviour for PauliString and Pauli.

## ✅ Checklist before requesting a review

- [x] I have made corresponding changes to the documentation.
- [x] The code follows the defined style guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] The code passes CI.