### PR TITLE
Remove qiskit from library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "ipykernel>=6.29.5,<7.0.0",
     "ipywidgets>=8.1.5,<9.0.0",
     "pandas>=2.2.3,<3.0.0",
-    "qiskit>=2.0.0,<3.0.0",
     "numba>=0.61.0",
     "numba-cuda>=0.4.0,<1.0.0",
     "sympy>=1.14.0,<2.0.0",

--- a/scripts/configs/cspell.json
+++ b/scripts/configs/cspell.json
@@ -153,7 +153,6 @@
         "pyzmq",
         "QAOS",
         "qcore",
-        "qiskit",
         "qubit",
         "qubits",
         "qudits",

--- a/scripts/configs/requirements.txt
+++ b/scripts/configs/requirements.txt
@@ -8,5 +8,4 @@ ipywidgets==8.1.5
 tqdm==4.67.1
 python-dotenv==1.0.1
 pandas==2.2.3
-qiskit==2.0.0
 galois==0.4.6

--- a/scripts/examples/notebooks/pxp_model.ipynb
+++ b/scripts/examples/notebooks/pxp_model.ipynb
@@ -75,9 +75,7 @@
     "h_reduced, conditioned_hams, reducing_circuit, eigenvalues = pauli_reduce(H)\n",
     "print(h_reduced)\n",
     "for h in conditioned_hams:\n",
-    "    print(h.n_qudits())\n",
-    "\n",
-    "reducing_circuit.show()"
+    "    print(h.n_qudits())"
    ]
   },
   {
@@ -99,7 +97,11 @@
    "source": []
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/src/sympleq/core/circuits/circuits.py
+++ b/src/sympleq/core/circuits/circuits.py
@@ -1,6 +1,5 @@
 from typing import Generator, overload, TypeVar
 import numpy as np
-from qiskit import QuantumCircuit
 from .gates import Gate, Hadamard as H, PHASE as S, SUM as CX, SWAP, CNOT, PauliGate
 from sympleq.core.paulis import PauliSum, PauliString, Pauli, PauliObject
 from .utils import embed_symplectic
@@ -187,23 +186,6 @@ class Circuit:
         for gate in self.gates:
             pauli_sum = gate.act(pauli)
             yield pauli_sum
-
-    def show(self):
-        if not np.all(np.array(self.dimensions) == 2):
-            print("Circuit dimensions are not all 2, using Qiskit QuantumCircuit, some gates may not be supported")
-        circuit = QuantumCircuit(len(self.dimensions))
-        dict = {'X': circuit.x, 'H': circuit.h, 'S': circuit.s, 'SUM': circuit.cx, 'CNOT': circuit.cx,
-                'Hdag': circuit.h}
-
-        for gate in self.gates:
-            name = gate.name
-            if len(gate.qudit_indices) == 2:
-                dict[name](gate.qudit_indices[0], gate.qudit_indices[1])
-            else:
-                dict[name](gate.qudit_indices[0])
-
-        print(circuit)
-        # return circuit
 
     def copy(self) -> 'Circuit':
         return Circuit(self.dimensions, self.gates.copy())


### PR DESCRIPTION
## 📝 Description
Remove qiskit from required packages. At the moment, it was only used to pretty-print circuits. It's better to delegate this to users or implement it ourselves in the future rather than importing a huge library.

## ✅ Checklist before requesting a review

- [x] I have made corresponding changes to the documentation.
- [x] The code follows the defined style guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] The code passes CI.