### PR TITLE
Remove pandas from requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 dependencies = [
     "numpy>=2.1.3,<3.0.0",
-    "ipykernel>=6.29.5,<7.0.0",
-    "ipywidgets>=8.1.5,<9.0.0",
     "numba>=0.61.0",
-    "numba-cuda>=0.4.0,<1.0.0",
     "sympy>=1.14.0,<2.0.0",
     "matplotlib>=3.10.0,<4.0.0",
     "scipy>=1.15.1,<2.0.0",
-    "tqdm>=4.67.1,<5.0.0",
     "networkx>=3.4.2,<4.0.0",
-    "python-dotenv>=1.0.1,<2.0.0",
     "galois>=0.4.6,<1.0.0",
 ]
 name = "sympleq"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "numpy>=2.1.3,<3.0.0",
     "ipykernel>=6.29.5,<7.0.0",
     "ipywidgets>=8.1.5,<9.0.0",
-    "pandas>=2.2.3,<3.0.0",
     "numba>=0.61.0",
     "numba-cuda>=0.4.0,<1.0.0",
     "sympy>=1.14.0,<2.0.0",

--- a/scripts/configs/dev_requirements.txt
+++ b/scripts/configs/dev_requirements.txt
@@ -1,6 +1,9 @@
+autopep8==2.2.0
 nbformat==5.10.4
-snakeviz==2.2.2
+ipykernel>=6.29.5,<7.0.0
+ipywidgets>=8.1.5,<9.0.0
 pytest==8.3.4
 pytest-benchmark==5.1.0
 pytest-cov==7.0.0
-autopep8==2.2.0
+snakeviz==2.2.2
+tqdm>=4.67.1,<5.0.0

--- a/scripts/configs/requirements.txt
+++ b/scripts/configs/requirements.txt
@@ -1,10 +1,7 @@
 numpy==2.1.3
-ipykernel==6.29.5
 matplotlib==3.10.0
 scipy==1.15.1
 networkx==3.4.2
-numba-cuda==0.4.0
-ipywidgets==8.1.5
-tqdm==4.67.1
-python-dotenv==1.0.1
+numba>=0.61.0
 galois==0.4.6
+sympy>=1.14.0,<2.0.0

--- a/scripts/configs/requirements.txt
+++ b/scripts/configs/requirements.txt
@@ -7,5 +7,4 @@ numba-cuda==0.4.0
 ipywidgets==8.1.5
 tqdm==4.67.1
 python-dotenv==1.0.1
-pandas==2.2.3
 galois==0.4.6

--- a/src/sympleq/models/chemistry.py
+++ b/src/sympleq/models/chemistry.py
@@ -1,6 +1,5 @@
-# pip install openfermion openfermionpyscf pyscf pandas
+# pip install openfermion openfermionpyscf pyscf
 import numpy as np
-import pandas as pd
 
 from openfermion.chem.molecular_data import MolecularData
 from openfermion.transforms.opconversions.jordan_wigner import jordan_wigner
@@ -62,17 +61,6 @@ def qubit_pauli_tableau(qubit_op, n_qubits=None):
         coeffs.append(coeff)
 
     return np.vstack(rows), np.array(coeffs, dtype=complex)
-
-
-def tableau_dataframe(tableau, coeffs):
-    n_qubits = tableau.shape[1] // 2
-    cols = [f"X{j}" for j in range(n_qubits)] + [f"Z{j}" for j in range(n_qubits)] + ["coeff_re", "coeff_im"]
-    df = pd.DataFrame(
-        np.hstack([tableau, np.column_stack([coeffs.real, coeffs.imag])]),
-        columns=cols
-    )
-    df[cols] = df[cols].astype(object)  # keep ints where possible
-    return df
 
 
 def chemistry_hamiltonian(geometry, basis="sto-3g", multiplicity=1, charge=0,


### PR DESCRIPTION
## 📝 Description
Pandas is only used to save tableaus to dataframe, we can leave that outside of the scope of sympleq.

## ✅ Checklist before requesting a review

- [x] I have made corresponding changes to the documentation.
- [x] The code follows the defined style guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] The code passes CI.