### PR TITLE
Fix mixed dimension case for `PauliString.acquired_phase`

### DIFF
--- a/src/sympleq/core/paulis/pauli_string.py
+++ b/src/sympleq/core/paulis/pauli_string.py
@@ -518,10 +518,10 @@ class PauliString(PauliObject):
         a = self.tableau[0]
         b = other_pauli.tableau[0]
 
-        # U is zeros with identity in lower-left n x n block
-        # This is equivalent to sum over j of 2 * x'_j * z_j
-        # U @ b selects b[:n] (x part) and puts it in lower half
-        phase = 2 * np.dot(a[n:], b[:n])  # THIS ASSUMES [1 | 1] is XZ, NOT Y
+        # Each qudit contributes omega_{d_j}^(z_j x'_j); the l / d_j factor rewrites those
+        # as powers of the shared zeta_l. This assumes [1 | 1] is XZ, not Y.
+        factors = self.lcm // self.dimensions
+        phase = 2 * np.dot(factors * a[n:], b[:n])
 
         return int(phase % (2 * self.lcm))
 

--- a/tests/core_tests/paulis_tests/pauli_test.py
+++ b/tests/core_tests/paulis_tests/pauli_test.py
@@ -462,6 +462,25 @@ class TestPaulis:
             f"with dimensions {dimensions}"
         )
 
+    def test_acquired_phase_on_mixed_dimensions(self):
+        dims = [2, 3]
+        lcm = 6
+
+        z0 = PauliString.from_string('x0z1 x0z0', dimensions=dims)
+        x0 = PauliString.from_string('x1z0 x0z0', dimensions=dims)
+        z1 = PauliString.from_string('x0z0 x0z1', dimensions=dims)
+        x1 = PauliString.from_string('x0z0 x1z0', dimensions=dims)
+
+        assert z0.acquired_phase(x0) == 2 * (lcm // dims[0])
+        assert z1.acquired_phase(x1) == 2 * (lcm // dims[1])
+        assert x0.acquired_phase(z0) == 0
+        assert x1.acquired_phase(z1) == 0
+
+        for a, b in [(z0, x0), (z1, x1), (x0, z0), (x1, z1)]:
+            assert a.acquired_phase(b) == (a * b).phases[0] % (2 * lcm), (
+                f'acquired_phase disagrees with __mul__ for {a} and {b}'
+            )
+
     def test_phase_and_dot_product(self):
 
         for _ in range(N_tests):


### PR DESCRIPTION
Add fix for mixed dimension also for PauliString.acquired_phase

## 📝 Description
 Please include a summary of the changes.

## ✅ Checklist before requesting a review

- [ ] I have made corresponding changes to the documentation.
- [ ] The code follows the defined style guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] The code passes CI.